### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,6 +8,8 @@ env:
 jobs:
   lint-and-format:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
 
@@ -24,6 +26,8 @@ jobs:
 
   security:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
Potential fix for [https://github.com/vasylenko/claude-desktop-extension-bear-notes/security/code-scanning/9](https://github.com/vasylenko/claude-desktop-extension-bear-notes/security/code-scanning/9)

To fix the problem, you should add a minimal explicit `permissions` block to the jobs that are currently missing it: `lint-and-format` and `security`. The block should grant only the least privilege required, which for these jobs is `contents: read`. This prevents those jobs from inheriting potentially unsafe default permissions. No additional methods, imports, or changes are required—this is a declarative update to the workflow YAML. Edit `.github/workflows/workflow.yml`, adding the following section to each affected job (after `runs-on: ubuntu-latest`):

```yaml
permissions:
  contents: read
```


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
