### PR TITLE
feat: add bear-replace-note tool and gate destructive actions behind config

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -28,7 +28,8 @@
         "${__dirname}/main.js"
       ],
       "env": {
-        "UI_DEBUG_TOGGLE": "${user_config.debug}"
+        "UI_DEBUG_TOGGLE": "${user_config.debug}",
+        "ALLOW_DESTRUCTIVE_ACTIONS": "${user_config.allow_destructive_actions}"
       }
     }
   },
@@ -37,6 +38,13 @@
       "type": "boolean",
       "title": "Debug Logging",
       "description": "Enable debug logging for troubleshooting",
+      "default": false,
+      "required": false
+    },
+    "allow_destructive_actions": {
+      "type": "boolean",
+      "title": "Allow Destructive Actions",
+      "description": "Enable tools that can modify or remove existing notes (replace content, archive notes). When disabled, only read and additive operations are available.",
       "default": false,
       "required": false
     }
@@ -73,6 +81,10 @@
     {
       "name": "bear-add-tag",
       "description": "Add one or more tags to an existing Bear note"
+    },
+    {
+      "name": "bear-replace-note",
+      "description": "Replace the content of an existing Bear note in-place, preserving the note ID"
     },
     {
       "name": "bear-archive-note",

--- a/src/bear-urls.ts
+++ b/src/bear-urls.ts
@@ -12,7 +12,7 @@ export interface BearUrlParams {
   tags?: string | undefined;
   id?: string | undefined;
   header?: string | undefined;
-  mode?: 'append' | 'prepend' | undefined;
+  mode?: 'append' | 'prepend' | 'replace' | 'replace_all' | undefined;
   file?: string | undefined;
   filename?: string | undefined;
   open_note?: 'yes' | 'no' | undefined;

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,8 @@ export const DEFAULT_SEARCH_LIMIT = 50;
 export const BEAR_DATABASE_PATH =
   'Library/Group Containers/9K33E3U3T4.net.shinyfrog.bear/Application Data/database.sqlite';
 
+export const DESTRUCTIVE_ACTIONS_ENABLED = process.env.ALLOW_DESTRUCTIVE_ACTIONS === 'true';
+
 export const ERROR_MESSAGES = {
   BEAR_DATABASE_NOT_FOUND:
     'Bear database not found. Please ensure Bear Notes is installed and has been opened at least once.',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -148,6 +148,12 @@ export function createToolResponse(text: string): Pick<CallToolResult, 'content'
   };
 }
 
+export function noteNotFoundResponse(id: string): Pick<CallToolResult, 'content'> {
+  return createToolResponse(`Note with ID '${id}' not found. The note may have been deleted, archived, or the ID may be incorrect.
+
+Use bear-search-notes to find the correct note identifier.`);
+}
+
 /**
  * Shared handler for adding text to Bear notes (append or prepend).
  * Consolidates common validation, execution, and response logic.
@@ -177,9 +183,7 @@ export async function handleAddText(
     const existingNote = getNoteContent(id.trim());
 
     if (!existingNote) {
-      return createToolResponse(`Note with ID '${id}' not found. The note may have been deleted, archived, or the ID may be incorrect.
-
-Use bear-search-notes to find the correct note identifier.`);
+      return noteNotFoundResponse(id);
     }
 
     // Strip markdown header syntax from header parameter for Bear API


### PR DESCRIPTION
## Summary
- Adds `bear-replace-note` tool for replacing note content in-place, preserving the note ID
- When only `text` is provided, replaces the body while keeping the existing title; when both `title` and `text` are provided, replaces everything
- Introduces `allow_destructive_actions` user config (default: `false`) that gates both `bear-replace-note` and `bear-archive-note` — when disabled, only read and additive operations are available
- Extracts shared "note not found" response into a `noteNotFoundResponse()` utility to eliminate duplication across 6 call sites
- Validates replacement text is non-empty to prevent accidental data loss

## Why
Destructive tools (replace, archive) carry higher risk than additive ones. Gating them behind an opt-in config gives users explicit control over which operations are available, matching the safety-first approach of the project.

--
Closes #48