### PR TITLE
fix: enforce read-only DB and relational tag filtering

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -36,7 +36,7 @@ export function openBearDatabase(): DatabaseSync {
   logger.info(`Opening Bear database at: ${databasePath}`);
 
   try {
-    const db = new DatabaseSync(databasePath);
+    const db = new DatabaseSync(databasePath, { readOnly: true });
 
     logger.debug('Bear database opened successfully');
     return db;

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -9,14 +9,14 @@ import {
 } from './utils.js';
 import { openBearDatabase } from './database.js';
 
-// SQL expression that decodes Bear's URL-encoded tag titles — mirrors decodeTagName() in tags.ts
+// SQL equivalent of decodeTagName() in tags.ts — both MUST apply the same transformations
 const DECODED_TAG_TITLE = "LOWER(TRIM(REPLACE(t.ZTITLE, '+', ' ')))";
 
 /**
  * Builds a SQL WHERE clause that matches a tag exactly or its nested children.
  * Escapes LIKE wildcards (%, _) in the tag name to prevent unintended pattern matching.
  */
-function buildTagMatchClause(tag: string): { sql: string; params: (string | number)[] } {
+function buildTagMatchClause(tag: string): { sql: string; params: string[] } {
   const normalizedTag = tag.trim().toLowerCase();
   const escapedTag = normalizedTag.replace(/[%_\\]/g, '\\$&');
 

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -228,8 +228,8 @@ export function searchNotes(
       queryParams.push(searchPattern, searchPattern, searchPattern);
     }
 
-    // Pinned and tag filtering - behavior depends on combination
-    if (hasPinnedFilter && hasTag) {
+    // Tag clause applies to both pinned+tag and tag-only paths (JOINs differ above)
+    if (hasTag) {
       const tagClause = buildTagMatchClause(tag);
       innerQuery += tagClause.sql;
       queryParams.push(...tagClause.params);
@@ -237,10 +237,6 @@ export function searchNotes(
       // All pinned notes: globally pinned OR pinned in any tag (matches Bear's "Pinned" section)
       innerQuery +=
         ' AND (note.ZPINNED = 1 OR EXISTS (SELECT 1 FROM Z_5PINNEDINTAGS pt WHERE pt.Z_5PINNEDNOTES = note.Z_PK))';
-    } else if (hasTag) {
-      const tagClause = buildTagMatchClause(tag);
-      innerQuery += tagClause.sql;
-      queryParams.push(...tagClause.params);
     }
 
     // Add date filtering

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -7,6 +7,7 @@ import { openBearDatabase } from './database.js';
  * - Replaces '+' with spaces (Bear's URL encoding)
  * - Converts to lowercase (matches Bear UI behavior)
  * - Trims whitespace
+ * Keep in sync with DECODED_TAG_TITLE in notes.ts — both MUST apply the same transformations.
  */
 function decodeTagName(encodedName: string): string {
   return encodedName.replace(/\+/g, ' ').trim().toLowerCase();

--- a/tests/system/inspector.ts
+++ b/tests/system/inspector.ts
@@ -88,7 +88,7 @@ export function extractNoteBody(openNoteResponse: string): string {
  * Extracts the first note ID from bear-search-notes response text.
  * The response format includes `ID: <uuid>` for each result.
  */
-export function extractNoteId(searchResponse: string): string {
+function extractNoteId(searchResponse: string): string {
   const match = searchResponse.match(/ID:\s+([A-Fa-f0-9-]+)/);
   if (!match) {
     throw new Error(`No note ID found in search response: ${searchResponse}`);

--- a/tests/system/inspector.ts
+++ b/tests/system/inspector.ts
@@ -95,3 +95,36 @@ export function extractNoteId(searchResponse: string): string {
   }
   return match[1];
 }
+
+/** Archive a note by ID, swallowing errors during cleanup. */
+export function archiveNote(id: string): void {
+  try {
+    callTool({ toolName: 'bear-archive-note', args: { id } });
+  } catch {
+    // Best-effort cleanup — don't fail the test
+  }
+}
+
+/**
+ * Archives all notes matching a search prefix.
+ * Intended for afterAll cleanup to remove stray test notes from interrupted runs.
+ */
+export function cleanupTestNotes(prefix: string): void {
+  try {
+    const searchResult = callTool({
+      toolName: 'bear-search-notes',
+      args: { term: prefix },
+    });
+    const idMatches = searchResult.matchAll(/ID:\s+([A-Fa-f0-9-]+)/g);
+    for (const match of idMatches) {
+      archiveNote(match[1]);
+    }
+  } catch {
+    // Best-effort — test notes may already be archived
+  }
+}
+
+/** Generates a unique note title scoped to a test run, preventing cross-run collisions. */
+export function uniqueTitle(prefix: string, label: string, runId: number): string {
+  return `${prefix} ${label} ${runId}`;
+}

--- a/tests/system/inspector.ts
+++ b/tests/system/inspector.ts
@@ -128,3 +128,12 @@ export function cleanupTestNotes(prefix: string): void {
 export function uniqueTitle(prefix: string, label: string, runId: number): string {
   return `${prefix} ${label} ${runId}`;
 }
+
+/** Search for a note by title and return its ID. */
+export function findNoteId(noteTitle: string): string {
+  const searchResult = callTool({
+    toolName: 'bear-search-notes',
+    args: { term: noteTitle },
+  });
+  return extractNoteId(searchResult);
+}

--- a/tests/system/note-conventions.test.ts
+++ b/tests/system/note-conventions.test.ts
@@ -7,7 +7,7 @@ import {
   callTool,
   cleanupTestNotes,
   extractNoteBody,
-  extractNoteId,
+  findNoteId,
   uniqueTitle,
 } from './inspector.js';
 
@@ -18,15 +18,6 @@ const FIXTURE_TEXT = readFileSync(
 
 const TEST_PREFIX = '[Bear-MCP-stest-note-convention]';
 const RUN_ID = Date.now();
-
-/** Search for a test note by its exact title and return its ID. */
-function findTestNote(noteTitle: string): string {
-  const searchResult = callTool({
-    toolName: 'bear-search-notes',
-    args: { term: noteTitle },
-  });
-  return extractNoteId(searchResult);
-}
 
 afterAll(() => {
   cleanupTestNotes(TEST_PREFIX);
@@ -44,7 +35,7 @@ describe('note conventions via MCP Inspector CLI', () => {
         // No env override — convention OFF by default
       });
 
-      noteId = findTestNote(title);
+      noteId = findNoteId(title);
 
       const openResult = callTool({
         toolName: 'bear-open-note',
@@ -74,7 +65,7 @@ describe('note conventions via MCP Inspector CLI', () => {
         env: { UI_ENABLE_NEW_NOTE_CONVENTION: 'true' },
       });
 
-      noteId = findTestNote(title);
+      noteId = findNoteId(title);
 
       const openResult = callTool({
         toolName: 'bear-open-note',
@@ -101,7 +92,7 @@ describe('note conventions via MCP Inspector CLI', () => {
         env: { UI_ENABLE_NEW_NOTE_CONVENTION: 'true' },
       });
 
-      noteId = findTestNote(title);
+      noteId = findNoteId(title);
 
       const openResult = callTool({
         toolName: 'bear-open-note',
@@ -130,7 +121,7 @@ describe('note conventions via MCP Inspector CLI', () => {
         env: { UI_ENABLE_NEW_NOTE_CONVENTION: 'true' },
       });
 
-      noteId = findTestNote(title);
+      noteId = findNoteId(title);
 
       const openResult = callTool({
         toolName: 'bear-open-note',

--- a/tests/system/note-conventions.test.ts
+++ b/tests/system/note-conventions.test.ts
@@ -2,7 +2,14 @@ import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import { afterAll, describe, expect, it } from 'vitest';
 
-import { callTool, extractNoteBody, extractNoteId } from './inspector.js';
+import {
+  archiveNote,
+  callTool,
+  cleanupTestNotes,
+  extractNoteBody,
+  extractNoteId,
+  uniqueTitle,
+} from './inspector.js';
 
 const FIXTURE_TEXT = readFileSync(
   resolve(import.meta.dirname, '../fixtures/sample-note.md'),
@@ -10,48 +17,24 @@ const FIXTURE_TEXT = readFileSync(
 );
 
 const TEST_PREFIX = '[Bear-MCP-stest-note-convention]';
-
-function uniqueTitle(label: string): string {
-  return `${TEST_PREFIX} ${label} ${Date.now()}`;
-}
+const RUN_ID = Date.now();
 
 /** Search for a test note by its exact title and return its ID. */
-function findTestNote(title: string): string {
+function findTestNote(noteTitle: string): string {
   const searchResult = callTool({
     toolName: 'bear-search-notes',
-    args: { term: title },
+    args: { term: noteTitle },
   });
   return extractNoteId(searchResult);
 }
 
-/** Archive a note by ID, swallowing errors during cleanup. */
-function archiveNote(id: string): void {
-  try {
-    callTool({ toolName: 'bear-archive-note', args: { id } });
-  } catch {
-    // Best-effort cleanup — don't fail the test
-  }
-}
-
 afterAll(() => {
-  // Safety sweep: archive any stray test notes
-  try {
-    const searchResult = callTool({
-      toolName: 'bear-search-notes',
-      args: { term: TEST_PREFIX },
-    });
-    const idMatches = searchResult.matchAll(/ID:\s+([A-Fa-f0-9-]+)/g);
-    for (const match of idMatches) {
-      archiveNote(match[1]);
-    }
-  } catch {
-    // Best-effort — test notes may already be archived
-  }
+  cleanupTestNotes(TEST_PREFIX);
 });
 
 describe('note conventions via MCP Inspector CLI', () => {
   it('convention OFF — tags placed by Bear via URL params', () => {
-    const title = uniqueTitle('Conv Off');
+    const title = uniqueTitle(TEST_PREFIX, 'Conv Off', RUN_ID);
     let noteId: string | undefined;
 
     try {
@@ -81,7 +64,7 @@ describe('note conventions via MCP Inspector CLI', () => {
   });
 
   it('convention ON — tags embedded in text body with separator', () => {
-    const title = uniqueTitle('Conv On Tags+Text');
+    const title = uniqueTitle(TEST_PREFIX, 'Conv On Tags+Text', RUN_ID);
     let noteId: string | undefined;
 
     try {
@@ -108,7 +91,7 @@ describe('note conventions via MCP Inspector CLI', () => {
   });
 
   it('convention ON — tags only, no text', () => {
-    const title = uniqueTitle('Conv On Tags Only');
+    const title = uniqueTitle(TEST_PREFIX, 'Conv On Tags Only', RUN_ID);
     let noteId: string | undefined;
 
     try {
@@ -137,7 +120,7 @@ describe('note conventions via MCP Inspector CLI', () => {
   });
 
   it('convention ON — no tags, text passes through unchanged', () => {
-    const title = uniqueTitle('Conv On No Tags');
+    const title = uniqueTitle(TEST_PREFIX, 'Conv On No Tags', RUN_ID);
     let noteId: string | undefined;
 
     try {

--- a/tests/system/tag-search.test.ts
+++ b/tests/system/tag-search.test.ts
@@ -1,0 +1,124 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { callTool, extractNoteId } from './inspector.js';
+
+const TEST_PREFIX = '[Bear-MCP-stest-tag-search]';
+const RUN_ID = Date.now();
+
+// Unique tag names scoped to this test run to avoid collisions with real data.
+// TAG_BASE is the "parent" tag; TAG_NESTED is a child; TAG_SIMILAR has the parent as a prefix.
+const TAG_BASE = `stest67-${RUN_ID}`;
+const TAG_NESTED = `${TAG_BASE}/child`;
+const TAG_SIMILAR = `${TAG_BASE}plus`;
+
+function uniqueTitle(label: string): string {
+  return `${TEST_PREFIX} ${label} ${RUN_ID}`;
+}
+
+/** Archive a note by ID, swallowing errors during cleanup. */
+function archiveNote(id: string): void {
+  try {
+    callTool({ toolName: 'bear-archive-note', args: { id } });
+  } catch {
+    // Best-effort cleanup
+  }
+}
+
+// Titles are deterministic per run — used to verify search result presence/absence.
+const TITLE_EXACT = uniqueTitle('Exact');
+const TITLE_NESTED = uniqueTitle('Nested');
+const TITLE_SIMILAR = uniqueTitle('Similar');
+
+const noteIds: string[] = [];
+
+beforeAll(() => {
+  // Create three notes with distinct tag relationships:
+  // "Exact" — tagged with TAG_BASE only
+  // "Nested" — tagged with TAG_NESTED (child of TAG_BASE)
+  // "Similar" — tagged with TAG_SIMILAR (prefix overlap, NOT a child)
+  for (const { title, tag } of [
+    { title: TITLE_EXACT, tag: TAG_BASE },
+    { title: TITLE_NESTED, tag: TAG_NESTED },
+    { title: TITLE_SIMILAR, tag: TAG_SIMILAR },
+  ]) {
+    callTool({ toolName: 'bear-create-note', args: { title, tags: tag } });
+    const searchResult = callTool({
+      toolName: 'bear-search-notes',
+      args: { term: title },
+    });
+    noteIds.push(extractNoteId(searchResult));
+  }
+});
+
+afterAll(() => {
+  // Archive notes created during this run
+  for (const id of noteIds) {
+    archiveNote(id);
+  }
+
+  // Safety sweep: archive any stray test notes from interrupted runs
+  try {
+    const searchResult = callTool({
+      toolName: 'bear-search-notes',
+      args: { term: TEST_PREFIX },
+    });
+    const idMatches = searchResult.matchAll(/ID:\s+([A-Fa-f0-9-]+)/g);
+    for (const match of idMatches) {
+      archiveNote(match[1]);
+    }
+  } catch {
+    // Best-effort — test notes may already be archived
+  }
+});
+
+describe('tag search via MCP Inspector CLI', () => {
+  it('exact tag returns the matching note', () => {
+    const result = callTool({
+      toolName: 'bear-search-notes',
+      args: { tag: TAG_BASE },
+    });
+
+    expect(result).toContain(TITLE_EXACT);
+  });
+
+  it('parent tag search includes notes with nested child tags', () => {
+    const result = callTool({
+      toolName: 'bear-search-notes',
+      args: { tag: TAG_BASE },
+    });
+
+    expect(result).toContain(TITLE_NESTED);
+  });
+
+  it('parent tag search excludes notes whose tag merely shares a prefix', () => {
+    const result = callTool({
+      toolName: 'bear-search-notes',
+      args: { tag: TAG_BASE },
+    });
+
+    // TAG_SIMILAR ("stest67-...plus") is a different tag, not a child of TAG_BASE
+    expect(result).not.toContain(TITLE_SIMILAR);
+  });
+
+  it('nested tag search returns only the nested-tagged note', () => {
+    const result = callTool({
+      toolName: 'bear-search-notes',
+      args: { tag: TAG_NESTED },
+    });
+
+    expect(result).toContain(TITLE_NESTED);
+    expect(result).not.toContain(TITLE_EXACT);
+    expect(result).not.toContain(TITLE_SIMILAR);
+  });
+
+  it('similar tag search returns only the similar-tagged note', () => {
+    const result = callTool({
+      toolName: 'bear-search-notes',
+      args: { tag: TAG_SIMILAR },
+    });
+
+    expect(result).toContain(TITLE_SIMILAR);
+    expect(result).not.toContain(TITLE_EXACT);
+    expect(result).not.toContain(TITLE_NESTED);
+  });
+});

--- a/tests/system/tag-search.test.ts
+++ b/tests/system/tag-search.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { archiveNote, callTool, cleanupTestNotes, extractNoteId, uniqueTitle } from './inspector.js';
+import { archiveNote, callTool, cleanupTestNotes, findNoteId, uniqueTitle } from './inspector.js';
 
 const TEST_PREFIX = '[Bear-MCP-stest-tag-search]';
 const RUN_ID = Date.now();
@@ -33,11 +33,7 @@ beforeAll(() => {
     { noteTitle: TITLE_SIMILAR, tag: TAG_SIMILAR },
   ]) {
     callTool({ toolName: 'bear-create-note', args: { title: noteTitle, tags: tag } });
-    const searchResult = callTool({
-      toolName: 'bear-search-notes',
-      args: { term: noteTitle },
-    });
-    noteIds.push(extractNoteId(searchResult));
+    noteIds.push(findNoteId(noteTitle));
   }
 });
 

--- a/tests/system/tag-search.test.ts
+++ b/tests/system/tag-search.test.ts
@@ -1,33 +1,24 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { callTool, extractNoteId } from './inspector.js';
+import { archiveNote, callTool, cleanupTestNotes, extractNoteId, uniqueTitle } from './inspector.js';
 
 const TEST_PREFIX = '[Bear-MCP-stest-tag-search]';
 const RUN_ID = Date.now();
 
-// Unique tag names scoped to this test run to avoid collisions with real data.
+// Tag names reference issue #67 (false-positive tag matching).
 // TAG_BASE is the "parent" tag; TAG_NESTED is a child; TAG_SIMILAR has the parent as a prefix.
 const TAG_BASE = `stest67-${RUN_ID}`;
 const TAG_NESTED = `${TAG_BASE}/child`;
 const TAG_SIMILAR = `${TAG_BASE}plus`;
 
-function uniqueTitle(label: string): string {
-  return `${TEST_PREFIX} ${label} ${RUN_ID}`;
-}
-
-/** Archive a note by ID, swallowing errors during cleanup. */
-function archiveNote(id: string): void {
-  try {
-    callTool({ toolName: 'bear-archive-note', args: { id } });
-  } catch {
-    // Best-effort cleanup
-  }
+function title(label: string): string {
+  return uniqueTitle(TEST_PREFIX, label, RUN_ID);
 }
 
 // Titles are deterministic per run — used to verify search result presence/absence.
-const TITLE_EXACT = uniqueTitle('Exact');
-const TITLE_NESTED = uniqueTitle('Nested');
-const TITLE_SIMILAR = uniqueTitle('Similar');
+const TITLE_EXACT = title('Exact');
+const TITLE_NESTED = title('Nested');
+const TITLE_SIMILAR = title('Similar');
 
 const noteIds: string[] = [];
 
@@ -36,39 +27,25 @@ beforeAll(() => {
   // "Exact" — tagged with TAG_BASE only
   // "Nested" — tagged with TAG_NESTED (child of TAG_BASE)
   // "Similar" — tagged with TAG_SIMILAR (prefix overlap, NOT a child)
-  for (const { title, tag } of [
-    { title: TITLE_EXACT, tag: TAG_BASE },
-    { title: TITLE_NESTED, tag: TAG_NESTED },
-    { title: TITLE_SIMILAR, tag: TAG_SIMILAR },
+  for (const { noteTitle, tag } of [
+    { noteTitle: TITLE_EXACT, tag: TAG_BASE },
+    { noteTitle: TITLE_NESTED, tag: TAG_NESTED },
+    { noteTitle: TITLE_SIMILAR, tag: TAG_SIMILAR },
   ]) {
-    callTool({ toolName: 'bear-create-note', args: { title, tags: tag } });
+    callTool({ toolName: 'bear-create-note', args: { title: noteTitle, tags: tag } });
     const searchResult = callTool({
       toolName: 'bear-search-notes',
-      args: { term: title },
+      args: { term: noteTitle },
     });
     noteIds.push(extractNoteId(searchResult));
   }
 });
 
 afterAll(() => {
-  // Archive notes created during this run
   for (const id of noteIds) {
     archiveNote(id);
   }
-
-  // Safety sweep: archive any stray test notes from interrupted runs
-  try {
-    const searchResult = callTool({
-      toolName: 'bear-search-notes',
-      args: { term: TEST_PREFIX },
-    });
-    const idMatches = searchResult.matchAll(/ID:\s+([A-Fa-f0-9-]+)/g);
-    for (const match of idMatches) {
-      archiveNote(match[1]);
-    }
-  } catch {
-    // Best-effort — test notes may already be archived
-  }
+  cleanupTestNotes(TEST_PREFIX);
 });
 
 describe('tag search via MCP Inspector CLI', () => {


### PR DESCRIPTION
## Summary
- **Enforce read-only SQLite connection** (#68): Pass `{ readOnly: true }` to `DatabaseSync` constructor, preventing any accidental writes to Bear's database at the driver level
- **Replace text-based tag search with relational JOINs** (#67): Tag-only and pinned+tag search paths now use `JOIN Z_5TAGS → ZSFNOTETAG` instead of `ZTEXT LIKE '%#tag%'`, eliminating false positives (e.g., `#car` matching `#career`, code blocks, URLs)
- Tag matching decodes `ZTITLE` via `REPLACE/TRIM/LOWER` in SQL (mirroring `decodeTagName()` in `tags.ts`) and supports nested tags (`career` → `career/meetings`) via `LIKE ? || '/%'`

Closes #67
Closes #68

## Test plan
- [x] `task build` passes (lint + format + 21 unit tests + compile)
- [x] Manual: search by tag `career` — should return notes tagged `career` and `career/meetings`, but NOT `mycareer`
- [x] Manual: search by tag with pinned filter — same relational matching behavior
- [x] Manual: verify database opens successfully in read-only mode (no behavioral change for reads)

Created with Claude Code under the supervision of Serhii Vasylenko