### PR TITLE
feat: return note ID from bear-create-note when title is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.0] - 2026-03-06
+
+### Changed
+- **`bear-create-note` returns the note ID** ([#66](https://github.com/vasylenko/claude-desktop-extension-bear-notes/issues/66)): When a title is provided, the tool now polls Bear's database after creation and returns the note's unique identifier. This lets AI agents reference the newly created note in follow-up operations (add text, add tag, etc.) without a separate search step. When no title is given or the lookup times out, the tool still succeeds — returning the ID is best-effort.
+
 ## [2.6.0] - 2026-03-04
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "bear-notes",
   "display_name": "Bear Notes",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "icon": "icon.png",
   "screenshots": ["screenshots/search-demo.png"],
   "description": "Bear Notes MCP server with TypeScript and native SQLite. Provides comprehensive Bear Notes integration for creating, searching, reading, and modifying notes.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bear-notes-mcp",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bear-notes-mcp",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bear-notes-mcp",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Bear Notes MCP server with TypeScript and native SQLite",
   "type": "module",
   "main": "dist/main.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = '2.6.0';
+export const APP_VERSION = '2.7.0';
 export const BEAR_URL_SCHEME = 'bear://x-callback-url/';
 export const CORE_DATA_EPOCH_OFFSET = 978307200; // 2001-01-01 to Unix epoch
 export const DEFAULT_SEARCH_LIMIT = 50;

--- a/src/database.ts
+++ b/src/database.ts
@@ -26,6 +26,19 @@ function getBearDatabasePath(): string {
 }
 
 /**
+ * Closes a Bear database connection, logging but swallowing close errors.
+ * Centralizes the try/catch-close pattern used after every DB operation.
+ */
+export function closeBearDatabase(db: DatabaseSync): void {
+  try {
+    db.close();
+    logger.debug('Database connection closed');
+  } catch (closeError) {
+    logger.error(`Failed to close database connection: ${closeError}`);
+  }
+}
+
+/**
  * Opens a read-only connection to Bear's SQLite database.
  *
  * @returns DatabaseSync instance for querying Bear notes

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import { APP_VERSION, ENABLE_CONTENT_REPLACEMENT, ENABLE_NEW_NOTE_CONVENTIONS } from './config.js';
 import { applyNoteConventions } from './note-conventions.js';
 import { cleanBase64, createToolResponse, handleNoteTextUpdate, logger } from './utils.js';
-import { getNoteContent, searchNotes } from './notes.js';
+import { awaitNoteCreation, getNoteContent, searchNotes } from './notes.js';
 import { findUntaggedNotes, listTags } from './tags.js';
 import { buildBearUrl, executeBearXCallbackApi } from './bear-urls.js';
 import type { BearTag } from './types.js';
@@ -86,7 +86,7 @@ server.registerTool(
   {
     title: 'Create New Note',
     description:
-      'Create a new note in your Bear library with optional title, content, and tags. The note will be immediately available in Bear app.',
+      'Create a new note in your Bear library with optional title, content, and tags. Returns the note ID when a title is provided, enabling immediate follow-up operations. The note will be immediately available in Bear app.',
     inputSchema: {
       title: z
         .string()
@@ -128,18 +128,24 @@ server.registerTool(
 
       await executeBearXCallbackApi(url);
 
+      let createdNoteId: string | undefined;
+      if (title) {
+        const createdNote = await awaitNoteCreation(title);
+        createdNoteId = createdNote?.identifier;
+      }
+
       const responseLines: string[] = ['Bear note created successfully!', ''];
 
       if (title) {
         responseLines.push(`Title: "${title}"`);
       }
 
-      if (text) {
-        responseLines.push(`Content: ${text.length} characters`);
-      }
-
       if (tags) {
         responseLines.push(`Tags: ${tags}`);
+      }
+
+      if (createdNoteId) {
+        responseLines.push(`Note ID: ${createdNoteId}`);
       }
 
       const hasContent = title || text || tags;

--- a/src/main.ts
+++ b/src/main.ts
@@ -128,11 +128,7 @@ server.registerTool(
 
       await executeBearXCallbackApi(url);
 
-      let createdNoteId: string | undefined;
-      if (title) {
-        const createdNote = await awaitNoteCreation(title);
-        createdNoteId = createdNote?.identifier;
-      }
+      const createdNoteId = title ? await awaitNoteCreation(title) : undefined;
 
       const responseLines: string[] = ['Bear note created successfully!', ''];
 

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -1,3 +1,5 @@
+import { setTimeout } from 'node:timers/promises';
+
 import type { BearNote, DateFilter } from './types.js';
 import { DEFAULT_SEARCH_LIMIT } from './config.js';
 import {
@@ -8,6 +10,10 @@ import {
   parseDateString,
 } from './utils.js';
 import { openBearDatabase } from './database.js';
+
+const POLL_INTERVAL_MS = 25;
+const POLL_TIMEOUT_MS = 2_000;
+const CREATION_LOOKBACK_MS = 10_000;
 
 // SQL equivalent of decodeTagName() in tags.ts — both MUST apply the same transformations
 const DECODED_TAG_TITLE = "LOWER(TRIM(REPLACE(t.ZTITLE, '+', ' ')))";
@@ -317,4 +323,60 @@ export function searchNotes(
   }
 
   return { notes: [], totalCount: 0 };
+}
+
+/**
+ * Polls Bear's SQLite database for a recently created note matching the given title.
+ * Designed for use after bear-create-note fires the URL API — the note creation already
+ * succeeded, so errors here degrade gracefully to null instead of throwing.
+ *
+ * @param title - Exact title to match (case-sensitive, as Bear stores it)
+ * @returns The created note, or null if not found within the timeout window
+ */
+export async function awaitNoteCreation(title: string): Promise<BearNote | null> {
+  logger.debug(`awaitNoteCreation: polling for note "${title}"`);
+
+  const sinceTimestamp = convertDateToCoreDataTimestamp(
+    new Date(Date.now() - CREATION_LOOKBACK_MS)
+  );
+
+  const db = openBearDatabase();
+
+  try {
+    const stmt = db.prepare(`
+      SELECT ZTITLE as title, ZUNIQUEIDENTIFIER as identifier,
+             ZCREATIONDATE as creationDate, ZMODIFICATIONDATE as modificationDate,
+             ZPINNED as pinned
+      FROM ZSFNOTE
+      WHERE ZTITLE = ? AND ZCREATIONDATE >= ?
+        AND ZARCHIVED = 0 AND ZTRASHED = 0 AND ZENCRYPTED = 0
+      ORDER BY ZCREATIONDATE DESC LIMIT 1
+    `);
+
+    const deadline = Date.now() + POLL_TIMEOUT_MS;
+
+    while (Date.now() < deadline) {
+      const row = stmt.get(title, sinceTimestamp) as Record<string, unknown> | undefined;
+      if (row) {
+        logger.debug(`awaitNoteCreation: found note "${title}"`);
+        return formatBearNote(row);
+      }
+      await setTimeout(POLL_INTERVAL_MS);
+    }
+
+    logger.info(`awaitNoteCreation: timed out waiting for note "${title}"`);
+    return null;
+  } catch (error) {
+    // Intentionally not using logAndThrow — the note was already created via URL API,
+    // failing to retrieve its ID should not turn a successful creation into an error
+    logger.error(`awaitNoteCreation failed: ${error}`);
+    return null;
+  } finally {
+    try {
+      db.close();
+      logger.debug('Database connection closed');
+    } catch (closeError) {
+      logger.error(`Failed to close database connection: ${closeError}`);
+    }
+  }
 }

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -9,10 +9,11 @@ import {
   logger,
   parseDateString,
 } from './utils.js';
-import { openBearDatabase } from './database.js';
+import { closeBearDatabase, openBearDatabase } from './database.js';
 
 const POLL_INTERVAL_MS = 25;
 const POLL_TIMEOUT_MS = 2_000;
+// Safety window wider than POLL_TIMEOUT_MS to avoid matching a stale note with the same title
 const CREATION_LOOKBACK_MS = 10_000;
 
 // SQL equivalent of decodeTagName() in tags.ts — both MUST apply the same transformations
@@ -147,12 +148,7 @@ export function getNoteContent(identifier: string): BearNote | null {
       `Database error: Failed to retrieve note content: ${error instanceof Error ? error.message : String(error)}`
     );
   } finally {
-    try {
-      db.close();
-      logger.debug('Database connection closed');
-    } catch (closeError) {
-      logger.error(`Failed to close database connection: ${closeError}`);
-    }
+    closeBearDatabase(db);
   }
   return null;
 }
@@ -314,26 +310,26 @@ export function searchNotes(
       `SQLite search query failed: ${error instanceof Error ? error.message : String(error)}`
     );
   } finally {
-    try {
-      db.close();
-      logger.debug('Database connection closed');
-    } catch (closeError) {
-      logger.error(`Failed to close database connection: ${closeError}`);
-    }
+    closeBearDatabase(db);
   }
 
   return { notes: [], totalCount: 0 };
 }
 
 /**
- * Polls Bear's SQLite database for a recently created note matching the given title.
+ * Polls Bear's SQLite database for the identifier of a recently created note.
  * Designed for use after bear-create-note fires the URL API — the note creation already
  * succeeded, so errors here degrade gracefully to null instead of throwing.
  *
  * @param title - Exact title to match (case-sensitive, as Bear stores it)
- * @returns The created note, or null if not found within the timeout window
+ * @returns The created note's identifier, or null if not found within the timeout window
  */
-export async function awaitNoteCreation(title: string): Promise<BearNote | null> {
+export async function awaitNoteCreation(title: string): Promise<string | null> {
+  if (!title?.trim()) {
+    logger.debug('awaitNoteCreation: skipped — no title provided');
+    return null;
+  }
+
   logger.debug(`awaitNoteCreation: polling for note "${title}"`);
 
   const sinceTimestamp = convertDateToCoreDataTimestamp(
@@ -344,9 +340,7 @@ export async function awaitNoteCreation(title: string): Promise<BearNote | null>
 
   try {
     const stmt = db.prepare(`
-      SELECT ZTITLE as title, ZUNIQUEIDENTIFIER as identifier,
-             ZCREATIONDATE as creationDate, ZMODIFICATIONDATE as modificationDate,
-             ZPINNED as pinned
+      SELECT ZUNIQUEIDENTIFIER as identifier
       FROM ZSFNOTE
       WHERE ZTITLE = ? AND ZCREATIONDATE >= ?
         AND ZARCHIVED = 0 AND ZTRASHED = 0 AND ZENCRYPTED = 0
@@ -356,10 +350,10 @@ export async function awaitNoteCreation(title: string): Promise<BearNote | null>
     const deadline = Date.now() + POLL_TIMEOUT_MS;
 
     while (Date.now() < deadline) {
-      const row = stmt.get(title, sinceTimestamp) as Record<string, unknown> | undefined;
+      const row = stmt.get(title, sinceTimestamp) as { identifier: string } | undefined;
       if (row) {
         logger.debug(`awaitNoteCreation: found note "${title}"`);
-        return formatBearNote(row);
+        return row.identifier;
       }
       await setTimeout(POLL_INTERVAL_MS);
     }
@@ -372,11 +366,6 @@ export async function awaitNoteCreation(title: string): Promise<BearNote | null>
     logger.error(`awaitNoteCreation failed: ${error}`);
     return null;
   } finally {
-    try {
-      db.close();
-      logger.debug('Database connection closed');
-    } catch (closeError) {
-      logger.error(`Failed to close database connection: ${closeError}`);
-    }
+    closeBearDatabase(db);
   }
 }

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -365,7 +365,7 @@ export async function awaitNoteCreation(title: string): Promise<string | null> {
   } catch (error) {
     // Intentionally not using logAndThrow — the note was already created via URL API,
     // failing to retrieve its ID should not turn a successful creation into an error
-    logger.error(`awaitNoteCreation failed: ${error}`);
+    logger.error('awaitNoteCreation failed:', error);
     return null;
   } finally {
     if (db) closeBearDatabase(db);

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -336,9 +336,11 @@ export async function awaitNoteCreation(title: string): Promise<string | null> {
     new Date(Date.now() - CREATION_LOOKBACK_MS)
   );
 
-  const db = openBearDatabase();
+  let db: ReturnType<typeof openBearDatabase> | undefined;
 
   try {
+    db = openBearDatabase();
+
     const stmt = db.prepare(`
       SELECT ZUNIQUEIDENTIFIER as identifier
       FROM ZSFNOTE
@@ -366,6 +368,6 @@ export async function awaitNoteCreation(title: string): Promise<string | null> {
     logger.error(`awaitNoteCreation failed: ${error}`);
     return null;
   } finally {
-    closeBearDatabase(db);
+    if (db) closeBearDatabase(db);
   }
 }

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -1,6 +1,6 @@
 import type { BearNote, BearTag } from './types.js';
 import { convertCoreDataTimestamp, logAndThrow, logger } from './utils.js';
-import { openBearDatabase } from './database.js';
+import { closeBearDatabase, openBearDatabase } from './database.js';
 
 /**
  * Decodes and normalizes Bear tag names.
@@ -132,12 +132,7 @@ export function listTags(): { tags: BearTag[]; totalCount: number } {
       `Database error: Failed to retrieve tags: ${error instanceof Error ? error.message : String(error)}`
     );
   } finally {
-    try {
-      db.close();
-      logger.debug('Database connection closed');
-    } catch (closeError) {
-      logger.error(`Failed to close database connection: ${closeError}`);
-    }
+    closeBearDatabase(db);
   }
 
   return { tags: [], totalCount: 0 };
@@ -201,12 +196,7 @@ export function findUntaggedNotes(limit: number = 50): { notes: BearNote[]; tota
       `Database error: Failed to find untagged notes: ${error instanceof Error ? error.message : String(error)}`
     );
   } finally {
-    try {
-      db.close();
-      logger.debug('Database connection closed');
-    } catch (closeError) {
-      logger.error(`Failed to close database connection: ${closeError}`);
-    }
+    closeBearDatabase(db);
   }
 
   return { notes: [], totalCount: 0 };

--- a/tests/system/create-note.test.ts
+++ b/tests/system/create-note.test.ts
@@ -1,6 +1,13 @@
 import { afterAll, describe, expect, it } from 'vitest';
 
-import { archiveNote, callTool, cleanupTestNotes, findNoteId, uniqueTitle } from './inspector.js';
+import {
+  archiveNote,
+  callTool,
+  cleanupTestNotes,
+  findNoteId,
+  tryExtractNoteId,
+  uniqueTitle,
+} from './inspector.js';
 
 const TEST_PREFIX = '[Bear-MCP-stest-create-note]';
 const RUN_ID = Date.now();
@@ -21,9 +28,8 @@ describe('bear-create-note returns note ID via MCP Inspector CLI', () => {
       });
 
       // Response must contain Note ID with a UUID
-      const idMatch = createResult.match(/Note ID:\s+([A-Fa-f0-9-]+)/);
-      expect(idMatch, `Expected "Note ID: <UUID>" in response:\n${createResult}`).not.toBeNull();
-      noteId = idMatch![1];
+      noteId = tryExtractNoteId(createResult) ?? undefined;
+      expect(noteId, `Expected "Note ID: <UUID>" in response:\n${createResult}`).toBeDefined();
 
       // Verify the returned ID is valid by opening the note
       const openResult = callTool({
@@ -48,7 +54,7 @@ describe('bear-create-note returns note ID via MCP Inspector CLI', () => {
       });
 
       // No title → no polling → no Note ID line
-      expect(createResult).not.toContain('Note ID:');
+      expect(tryExtractNoteId(createResult)).toBeNull();
 
       // Find the orphan note by its unique marker text so we can clean it up
       noteId = findNoteId(marker);

--- a/tests/system/create-note.test.ts
+++ b/tests/system/create-note.test.ts
@@ -1,0 +1,59 @@
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { archiveNote, callTool, cleanupTestNotes, findNoteId, uniqueTitle } from './inspector.js';
+
+const TEST_PREFIX = '[Bear-MCP-stest-create-note]';
+const RUN_ID = Date.now();
+
+afterAll(() => {
+  cleanupTestNotes(TEST_PREFIX);
+});
+
+describe('bear-create-note returns note ID via MCP Inspector CLI', () => {
+  it('returns note ID when title is provided', () => {
+    const title = uniqueTitle(TEST_PREFIX, 'With Title', RUN_ID);
+    let noteId: string | undefined;
+
+    try {
+      const createResult = callTool({
+        toolName: 'bear-create-note',
+        args: { title, text: 'System test content', tags: 'system-test' },
+      });
+
+      // Response must contain Note ID with a UUID
+      const idMatch = createResult.match(/Note ID:\s+([A-Fa-f0-9-]+)/);
+      expect(idMatch, `Expected "Note ID: <UUID>" in response:\n${createResult}`).not.toBeNull();
+      noteId = idMatch![1];
+
+      // Verify the returned ID is valid by opening the note
+      const openResult = callTool({
+        toolName: 'bear-open-note',
+        args: { id: noteId },
+      });
+
+      expect(openResult).toContain(title);
+    } finally {
+      if (noteId) archiveNote(noteId);
+    }
+  });
+
+  it('does not return note ID when no title is provided', () => {
+    const marker = `${TEST_PREFIX} no-title ${crypto.randomUUID()}`;
+    let noteId: string | undefined;
+
+    try {
+      const createResult = callTool({
+        toolName: 'bear-create-note',
+        args: { text: marker, tags: 'system-test' },
+      });
+
+      // No title → no polling → no Note ID line
+      expect(createResult).not.toContain('Note ID:');
+
+      // Find the orphan note by its unique marker text so we can clean it up
+      noteId = findNoteId(marker);
+    } finally {
+      if (noteId) archiveNote(noteId);
+    }
+  });
+});

--- a/tests/system/inspector.ts
+++ b/tests/system/inspector.ts
@@ -83,16 +83,24 @@ export function extractNoteBody(openNoteResponse: string): string {
   return bodyWithFooter;
 }
 
+const NOTE_ID_REGEX = /ID:\s+([A-Fa-f0-9-]+)/;
+
+/** Extracts a note ID from any MCP response containing "ID: <uuid>", or null if absent. */
+export function tryExtractNoteId(response: string): string | null {
+  const match = response.match(NOTE_ID_REGEX);
+  return match ? match[1] : null;
+}
+
 /**
  * Extracts the first note ID from bear-search-notes response text.
  * The response format includes `ID: <uuid>` for each result.
  */
 function extractNoteId(searchResponse: string): string {
-  const match = searchResponse.match(/ID:\s+([A-Fa-f0-9-]+)/);
-  if (!match) {
+  const id = tryExtractNoteId(searchResponse);
+  if (!id) {
     throw new Error(`No note ID found in search response: ${searchResponse}`);
   }
-  return match[1];
+  return id;
 }
 
 /** Archive a note by ID, swallowing errors during cleanup. */
@@ -114,7 +122,7 @@ export function cleanupTestNotes(prefix: string): void {
       toolName: 'bear-search-notes',
       args: { term: prefix },
     });
-    const idMatches = searchResult.matchAll(/ID:\s+([A-Fa-f0-9-]+)/g);
+    const idMatches = searchResult.matchAll(new RegExp(NOTE_ID_REGEX, 'g'));
     for (const match of idMatches) {
       archiveNote(match[1]);
     }

--- a/tests/system/inspector.ts
+++ b/tests/system/inspector.ts
@@ -6,7 +6,7 @@ export { setTimeout as sleep } from 'node:timers/promises';
 const SERVER_PATH = resolve(import.meta.dirname, '../../dist/main.js');
 
 /** Timeout for a single MCP Inspector CLI tool call (ms). */
-export const TOOL_CALL_TIMEOUT = 5_000;
+export const TOOL_CALL_TIMEOUT = 10_000;
 
 interface CallToolOptions {
   toolName: string;


### PR DESCRIPTION
Poll Bear's SQLite database after URL API fires to retrieve the created note's UUID. Enables downstream tools to reference the note by ID without a separate search step.

Closes #66

