### PR TITLE
fix: show attachment filenames even when OCR text is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Attachments without OCR text no longer silently disappear** ([#79](https://github.com/vasylenko/claude-desktop-extension-bear-notes/issues/79)): When a note had attachments that Bear could not extract text from (e.g., MHTML files), those attachments were omitted entirely — making it look like the note had no files. Attachment filenames now always appear, with a note indicating when file content is not available.
+
 ## [2.7.0] - 2026-03-06
 
 ### Changed

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -122,8 +122,11 @@ export function getNoteContent(identifier: string): BearNote | null {
       const filename = rowData.filename as string;
       const fileContent = rowData.fileContent as string;
 
-      if (filename && fileContent && fileContent.trim()) {
-        fileContents.push(`##${filename}\n\n${fileContent.trim()}`);
+      if (filename) {
+        const content = fileContent?.trim()
+          ? fileContent.trim()
+          : '*[File content not available — Bear has not extracted text from this file type]*';
+        fileContents.push(`##${filename}\n\n${content}`);
       }
     }
 

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -123,8 +123,9 @@ export function getNoteContent(identifier: string): BearNote | null {
       const fileContent = rowData.fileContent as string;
 
       if (filename) {
-        const content = fileContent?.trim()
-          ? fileContent.trim()
+        const trimmed = fileContent?.trim();
+        const content = trimmed
+          ? trimmed
           : '*[File content not available — Bear has not extracted text from this file type]*';
         fileContents.push(`##${filename}\n\n${content}`);
       }


### PR DESCRIPTION
## Summary
- `bear-open-note` now shows filenames for all attachments, even when Bear hasn't extracted text from the file (e.g., MHTML files)
- When OCR text is unavailable, a fallback message is shown: *"File content not available — Bear has not extracted text from this file type"*
- Previously, these attachments were silently dropped, causing "No files attached" to appear even when files existed

## Why
Files without OCR text (like MHTML) were invisible to users — no filename, no indication they exist. This small UX fix ensures users always see what's attached to their notes.

--
Closes #79

Created with Claude Code under the supervision of Serhii Vasylenko