### PR TITLE
feat: add bear-rename-tag and bear-delete-tag tools

### DIFF
--- a/.claude/contexts/SPECIFICATION.md
+++ b/.claude/contexts/SPECIFICATION.md
@@ -1,210 +1,122 @@
 # Project Specification: Bear Notes MCP Bundle
 
-## Product Overview
+## What This Document Is For
 
-**Name:** Bear Notes MCP Bundle
-**Type:** MCP Bundle (.mcpb)
-**Platform:** macOS only
-**Repository:** https://github.com/vasylenko/claude-desktop-extension-bear-notes
-
-### Purpose
-Provides seamless integration between Claude Desktop and Bear Notes app, enabling AI-assisted note management through direct database access and Bear's native API.
-
-### Value Proposition
-- **Privacy-first**: All operations are local-only, zero network transmission
-- **Full-text search**: Includes OCR'd content from attached images and PDFs
-- **Type-safe**: Built with TypeScript for reliability
-- **Supply chain secure**: Uses Node.js native SQLite instead of third-party binaries
+Architecture decisions, system boundaries, and design constraints that shape how the codebase works. Tool descriptions and feature lists live in `manifest.json` and `README.md` — not here.
 
 ---
 
-## Core Capabilities
+## System Architecture
 
-### 1. Search Notes (`bear-search-notes`)
-**Purpose:** Find notes by content, tags, or date ranges
-**Implementation:** Direct SQLite database query with LEFT JOIN for file content
-**Features:**
-- Full-text search across note titles, content, and OCR'd attachments
-- Tag filtering (without # prefix)
-- Date filtering (created/modified before/after with relative date support)
-- Configurable result limit (default: 50)
-- Returns metadata only for performance
+### Hybrid Data Access Model
 
-**Technical Details:**
-- Read-only, idempotent operation
-- Searches ZSFNOTE and ZSFNOTEFILE tables
-- Excludes archived, trashed, and encrypted notes
-- Results sorted by modification date (DESC)
+The server uses two distinct paths to interact with Bear, chosen to avoid corrupting Bear's database while maximizing read performance:
 
-### 2. Read Note (`bear-open-note`)
-**Purpose:** Retrieve full content of a specific note
-**Implementation:** SQLite query with file content aggregation
-**Features:**
-- Returns complete note text with markdown formatting
-- Appends attached file content with clear labeling
-- Includes metadata (title, dates, ID)
+```
+  MCP Client (Claude Desktop)
+        │
+        ▼
+  MCP Server (main.ts)
+        │
+        ├── READ path ──▶ Bear SQLite DB (direct, read-only)
+        │                  notes.ts, tags.ts
+        │
+        └── WRITE path ──▶ Bear x-callback-url (fire-and-forget)
+                           bear-urls.ts → macOS `open -g` subprocess
+```
 
-**Technical Details:**
-- Read-only, idempotent operation
-- Aggregates multiple rows (note + files) into single response
-- File content labeled as `## filename` sections
+**Why not just use the database for everything?** Writing directly to Bear's Core Data SQLite would risk corruption — Bear doesn't expect external writers and could overwrite changes or crash.
 
-### 3. Create Note (`bear-create-note`)
-**Purpose:** Create new notes programmatically
-**Implementation:** Bear x-callback-url API via macOS `open` command
-**Features:**
-- Optional title, content, tags
-- Returns creation confirmation
-- Note available in Bear immediately
+**Why not just use x-callback-url for everything?** Bear's x-callback-url has no x-success callback that works without a running server to receive it. Reads via URL would require polling or a callback server. Direct SQLite is faster and simpler for reads.
 
-**Technical Details:**
-- Non-idempotent, open-world operation
-- Uses subprocess execution (spawn 'open' with -g flag to prevent focus steal)
-- URL parameter encoding via URLSearchParams
+### Fire-and-Forget Write Model
 
-### 4. Add Text (`bear-add-text`)
-**Purpose:** Add content to existing notes at beginning or end
-**Implementation:** Bear x-callback-url API with mode parameter
-**Features:**
-- Position parameter: 'beginning' (prepend) or 'end' (append, default)
-- Section targeting via header parameter
-- Automatic new line insertion
-- Requires note ID from search
+All write operations go through the URL path. This is intentionally one-way:
 
-**Technical Details:**
-- Destructive, non-idempotent operation
-- Uses `new_line=yes` parameter
-- Section targeting via header parameter
+- The server builds a URL, hands it to macOS, and gets back only an exit code
+- Bear processes the URL asynchronously — there's no confirmation that the operation succeeded inside Bear
+- For note-level writes, the server does pre-flight validation via the DB read path (note exists? section exists?) to catch errors early rather than letting Bear silently fail
+- For global operations (tag rename/delete), no pre-flight check is possible — Bear silently no-ops on missing targets
 
-### 5. Add File (`bear-add-file`)
-**Purpose:** Attach files to existing notes
-**Implementation:** Bear x-callback-url API with base64-encoded content
-**Features:**
-- Accepts base64-encoded file content
-- Supports all file types (images, PDFs, documents, etc.)
-- Can target note by ID or title
+### Background Execution
 
-**Technical Details:**
-- Destructive, non-idempotent operation
-- Base64 content cleaned of line breaks before URL encoding
-- Validates note existence before attempting attachment
-
-### 6. List Tags (`bear-list-tags`)
-**Purpose:** Display all tags in the Bear library
-**Implementation:** Direct SQLite query on ZSFNOTETAG table
-**Features:**
-- Returns hierarchical tree structure
-- Includes note counts per tag
-- Shows nested tags with proper indentation
-
-**Technical Details:**
-- Read-only, idempotent operation
-- Builds tree from flat tag list using path separators
-- Excludes system tags
-
-### 7. Find Untagged Notes (`bear-find-untagged-notes`)
-**Purpose:** Find notes without any tags
-**Implementation:** SQLite query with LEFT JOIN exclusion
-**Features:**
-- Returns notes that have no tags assigned
-- Configurable result limit (default: 50)
-- Useful for organization workflows
-
-**Technical Details:**
-- Read-only, idempotent operation
-- Excludes archived, trashed, and encrypted notes
-
-### 8. Add Tag (`bear-add-tag`)
-**Purpose:** Add tags to existing notes
-**Implementation:** Bear x-callback-url API with tags parameter
-**Features:**
-- Add one or more tags at once
-- Tags added at beginning of note
-- Supports nested tags (e.g., "work/meetings")
-
-**Technical Details:**
-- Non-destructive, non-idempotent operation
-- Validates note existence before adding tags
-- Uses prepend mode with tags parameter
+All write operations execute in the background without disrupting the user's Bear UI. The principle: the user is working in Claude Desktop, not Bear — writes should never steal focus, open windows, or switch the active note.
 
 ---
 
-## Technical Architecture
+## Safety Gates
 
-### Technology Stack
-- **Language:** TypeScript
-- **Runtime:** Node.js >=22.5.0
-- **MCP SDK:** @modelcontextprotocol/sdk
-- **Database:** Native Node.js SQLite (node:sqlite)
-- **Validation:** Zod
-- **Build:** TypeScript compiler (tsc)
-- **Bundling:** @anthropic-ai/mcpb
+### Content Replacement Is Opt-In
 
-### Key Design Decisions
+The ability to overwrite note content (full body or specific sections) is **disabled by default**. Users must explicitly enable "Content Replacement" in extension settings before `bear-replace-text` works. This prevents AI from accidentally destroying note content.
 
-1. **Native SQLite over third-party packages**
-   - Rationale: Avoid macOS security blocks on unsigned binaries
-   - Benefit: Supply chain security, no binary distribution
+### No Note Deletion
 
-2. **Hybrid approach (SQLite + x-callback-url)**
-   - Reads: Direct database (faster, no callback handling)
-   - Writes: x-callback-url (no DB corruption risk)
-   - Rationale: x-success callback would require server/binary
-
-3. **File content always included**
-   - OCR'd text from images/PDFs included in search and read
-   - Labeled clearly with filename headers
-   - Rationale: Maximize search comprehensiveness
-
-4. **Background execution for writes**
-   - Uses `open -g` flag to prevent Bear from stealing focus
-   - Better UX when working in Claude Desktop
-
-5. **Error handling strategy**
-   - Database errors thrown immediately
-   - URL execution errors captured from stderr
-   - All errors logged with debug logger
-   - User-friendly error messages via ERROR_MESSAGES config
+There is no delete tool. Too destructive for AI-assisted workflows — a misidentified note ID would mean permanent data loss. Archiving is the closest alternative and is reversible in Bear.
 
 ---
 
-## Known Limitations & Constraints
+## Key Design Constraints
 
-### Functional Limitations
-- No note deletion (intentional - destructive operation)
-- No support for encrypted notes (excluded from queries)
-- x-callback-url has no response parsing (fire-and-forget)
+### Bear's Database
 
-### Technical Constraints
-- No automated testing (database access requires real Bear DB)
-- No cross-platform support (Bear is macOS only)
+Bear uses Core Data with SQLite. The schema is undocumented — our understanding comes from reverse-engineering (see `BEAR_DATABASE_SCHEMA.md`). The database path is discovered via Bear's app container at `~/Library/Group Containers/group.com.shinyfrog.bear/`. Key fragility points:
 
-## Success Metrics
+- Tag name decoding logic exists in two places (SQL expression in `notes.ts` and TypeScript function in `tags.ts`) — these must produce identical results. Bidirectional comments link them.
+- Tag hierarchy is not stored relationally — it's reconstructed at query time by splitting slash-delimited paths.
+- All queries exclude trashed, archived, and encrypted notes to match what Bear's UI shows.
 
-### Adoption
-- GitHub stars/forks
-- Issue reports and feature requests
-- Download count from releases
+### Bear's URL Scheme Quirks
 
-### Quality
-- Zero supply chain vulnerabilities (Snyk badge)
-- Passing CI/CD workflows
-- Low bug report rate
+- **Space encoding**: Bear expects `%20`, not `+`. `URLSearchParams` encodes spaces as `+` by default, so a global replace is applied after encoding.
+- **No response data**: Unlike standard x-callback-url, Bear's implementation doesn't return data via x-success in a way the server can capture without a callback receiver.
+- **Note creation has no ID in response**: After creating a note, the server polls the database to find the new note's ID by title match. This is best-effort and may time out.
 
-### User Satisfaction
-- Positive feedback in discussions
-- Minimal support requests
-- Community contributions
+### Platform Constraints
+
+- **macOS only**: Bear is a macOS/iOS app; the database is at a macOS-specific path; `open -g` is a macOS command.
+- **Node.js native SQLite**: Uses `node:sqlite` (experimental) to avoid third-party binary dependencies that macOS Gatekeeper would block.
+
+### Intentional Exclusions
+
+- **Encrypted notes**: Bear encrypts content in the DB. Excluded from all queries.
+- **Per-tag pinning**: Bear's URL scheme supports `pin=yes` for global pinning but has no action for pinning within a specific tag.
+- **Write verification**: No way to confirm Bear processed a URL action. Exit code 0 from `open` only means macOS accepted the URL, not that Bear acted on it.
+
+---
+
+## Error Handling Contract
+
+Two tiers of errors, from the client's perspective:
+
+| Tier | When | What the client sees |
+|------|------|---------------------|
+| Soft error | Expected condition (note not found, section missing, feature disabled) | Normal text response describing the problem and suggesting a fix |
+| Hard error | Unexpected failure (subprocess crash, DB error) | MCP-level error response |
+
+Note-level write tools do pre-flight DB validation to turn silent Bear failures into clear soft errors. Global tag operations cannot be pre-validated.
+
+Neither tier uses the MCP SDK's `isError` field — this is a potential future improvement.
+
+---
+
+## Testing Constraints
+
+- **System tests require a live Bear installation** — they create real notes, modify them, and verify results. Cannot run in CI.
+- **System tests share Bear state** — they run sequentially, each suite managing its own test data with unique prefixes and cleanup in afterAll.
+- **Write operation timing** — after a URL write, tests pause briefly before reading back via SQLite, giving Bear time to process the callback.
+
+---
 
 ## References
 
 ### Documentation
 - [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/README.md)
-- [MCPB Specification](https://github.com/modelcontextprotocol/mcpb/blob/main/README.md)
-- [MCPB Manifest](https://github.com/modelcontextprotocol/mcpb/blob/main/MANIFEST.md)
-- [MCPB CLI](https://github.com/modelcontextprotocol/mcpb/blob/main/CLI.md)
+- [MCPB Specification](https://github.com/anthropics/mcpb/blob/main/README.md)
+- [MCPB Manifest](https://github.com/anthropics/mcpb/blob/main/MANIFEST.md)
+- [MCPB CLI](https://github.com/anthropics/mcpb/blob/main/CLI.md)
 - [Taskfile Documentation](https://taskfile.dev/docs/guide)
 
 ### Bear Notes API
 - [Bear x-callback-url API](https://bear.app/faq/X-callback-url%20Scheme%20documentation/)
-- Bear Database Schema: Internal reverse-engineering
+- Bear Database Schema: see `.claude/contexts/BEAR_DATABASE_SCHEMA.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.8.0]
+
+### Added
+- **`bear-rename-tag`** tool ([#63](https://github.com/vasylenko/claude-desktop-extension-bear-notes/issues/63)) — rename a tag across all notes in your Bear library. Useful for reorganizing tag taxonomy, fixing typos, or restructuring tag hierarchies.
+- **`bear-delete-tag`** tool ([#64](https://github.com/vasylenko/claude-desktop-extension-bear-notes/issues/64)) — delete a tag from all notes without affecting the notes themselves.
 
 ### Fixed
 - **`bear-list-tags` no longer shows ghost tags from excluded notes** ([#77](https://github.com/vasylenko/claude-desktop-extension-bear-notes/issues/77)): Tag counts previously included trashed, archived, and encrypted notes, causing tags that existed only on those notes to appear in the list with inflated counts. Tag results now match what Bear's UI shows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.8.0]
+## [UNRELEASED]
 
 ### Added
 - **`bear-rename-tag`** tool ([#63](https://github.com/vasylenko/claude-desktop-extension-bear-notes/issues/63)) — rename a tag across all notes in your Bear library. Useful for reorganizing tag taxonomy, fixing typos, or restructuring tag hierarchies.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ You are world-class NodeJS developer, senior engineer with a vast experience in 
 
 # Additional technical context
 
-1 - Project Specification - .claude/contexts/SPECIFICATION.md - use this to get the details about technologies and implementation of the features
+1 - Project Specification - .claude/contexts/SPECIFICATION.md - read this before making architectural changes; covers system boundaries, design constraints, safety gates, and the rationale behind the hybrid read/write model
 
 2 - Bear database schema brief - .claude/contexts/BEAR_DATABASE_SCHEMA.md - use this when working with tasks related to database access as a starting point
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Add to your MCP configuration file:
 - **`bear-find-untagged-notes`** - Find notes in your Bear library that have no tags assigned
 - **`bear-add-tag`** - Add one or more tags to an existing Bear note
 - **`bear-archive-note`** - Archive a Bear note to remove it from active lists without deleting it
+- **`bear-rename-tag`** - Rename a tag across all notes in your Bear library
+- **`bear-delete-tag`** - Delete a tag from all notes in your Bear library without affecting the notes
 <!-- TOOLS:END -->
 
 ## ⚙️ Configuration

--- a/docs/NPM.md
+++ b/docs/NPM.md
@@ -26,6 +26,8 @@ Search, read, create, and update your Bear Notes from any AI assistant.
 - **`bear-find-untagged-notes`** - Find notes in your Bear library that have no tags assigned
 - **`bear-add-tag`** - Add one or more tags to an existing Bear note
 - **`bear-archive-note`** - Archive a Bear note to remove it from active lists without deleting it
+- **`bear-rename-tag`** - Rename a tag across all notes in your Bear library
+- **`bear-delete-tag`** - Delete a tag from all notes in your Bear library without affecting the notes
 <!-- TOOLS:END -->
 
 **Requirements**: Node.js 24.13.0+

--- a/issues/test_issue.md
+++ b/issues/test_issue.md
@@ -1,1 +1,0 @@
-Test Issue: This is a test issue created for demonstration purposes.

--- a/manifest.json
+++ b/manifest.json
@@ -97,6 +97,14 @@
     {
       "name": "bear-archive-note",
       "description": "Archive a Bear note to remove it from active lists without deleting it"
+    },
+    {
+      "name": "bear-rename-tag",
+      "description": "Rename a tag across all notes in your Bear library"
+    },
+    {
+      "name": "bear-delete-tag",
+      "description": "Delete a tag from all notes in your Bear library without affecting the notes"
     }
   ],
   "keywords": [

--- a/src/bear-urls.ts
+++ b/src/bear-urls.ts
@@ -16,6 +16,8 @@ export interface BearUrlParams {
   new_line?: 'yes' | 'no' | undefined;
   file?: string | undefined;
   filename?: string | undefined;
+  name?: string | undefined;
+  new_name?: string | undefined;
   open_note?: 'yes' | 'no' | undefined;
   new_window?: 'yes' | 'no' | undefined;
   show_window?: 'yes' | 'no' | undefined;
@@ -40,7 +42,17 @@ export function buildBearUrl(action: string, params: BearUrlParams = {}): string
   const urlParams = new URLSearchParams();
 
   // Add provided parameters with proper encoding
-  const stringParams = ['title', 'text', 'tags', 'id', 'header', 'file', 'filename'] as const;
+  const stringParams = [
+    'title',
+    'text',
+    'tags',
+    'id',
+    'header',
+    'file',
+    'filename',
+    'name',
+    'new_name',
+  ] as const;
   for (const key of stringParams) {
     const value = params[key];
     if (value !== undefined && value.trim()) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -709,6 +709,101 @@ The note has been moved to Bear's archive.`);
   }
 );
 
+server.registerTool(
+  'bear-rename-tag',
+  {
+    title: 'Rename Tag',
+    description:
+      'Rename a tag across all notes in your Bear library. Useful for reorganizing tag taxonomy, fixing typos, or restructuring tag hierarchies. Use bear-list-tags first to see existing tags.',
+    inputSchema: {
+      name: z
+        .string()
+        .trim()
+        .min(1, 'Tag name is required')
+        .describe('Current tag name to rename (without # symbol)'),
+      new_name: z
+        .string()
+        .trim()
+        .min(1, 'New tag name is required')
+        .describe(
+          'New tag name (without # symbol). Use slashes for hierarchy, e.g., "archive/old-project"'
+        ),
+    },
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+  },
+  async ({ name, new_name }): Promise<CallToolResult> => {
+    logger.info(`bear-rename-tag called with name: "${name}", new_name: "${new_name}"`);
+
+    try {
+      const url = buildBearUrl('rename-tag', {
+        name,
+        new_name,
+        show_window: 'no',
+      });
+
+      await executeBearXCallbackApi(url);
+
+      return createToolResponse(`Tag renamed successfully!
+
+From: #${name}
+To: #${new_name}
+
+The tag has been renamed across all notes in your Bear library.`);
+    } catch (error) {
+      logger.error('bear-rename-tag failed:', error);
+      throw error;
+    }
+  }
+);
+
+server.registerTool(
+  'bear-delete-tag',
+  {
+    title: 'Delete Tag',
+    description:
+      'Delete a tag from all notes in your Bear library. Removes the tag but preserves the notes themselves. Use bear-list-tags first to see existing tags.',
+    inputSchema: {
+      name: z
+        .string()
+        .trim()
+        .min(1, 'Tag name is required')
+        .describe('Tag name to delete (without # symbol)'),
+    },
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+  },
+  async ({ name }): Promise<CallToolResult> => {
+    logger.info(`bear-delete-tag called with name: "${name}"`);
+
+    try {
+      const url = buildBearUrl('delete-tag', {
+        name,
+        show_window: 'no',
+      });
+
+      await executeBearXCallbackApi(url);
+
+      return createToolResponse(`Tag deleted successfully!
+
+Tag: #${name}
+
+The tag has been removed from all notes. The notes themselves are not affected.`);
+    } catch (error) {
+      logger.error('bear-delete-tag failed:', error);
+      throw error;
+    }
+  }
+);
+
 async function main(): Promise<void> {
   logger.info(`Bear Notes MCP Server initializing... Version: ${APP_VERSION}`);
   logger.debug(`Debug logs enabled: ${logger.debug.enabled}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -743,6 +743,8 @@ server.registerTool(
       const url = buildBearUrl('rename-tag', {
         name,
         new_name,
+        open_note: 'no',
+        new_window: 'no',
         show_window: 'no',
       });
 
@@ -787,6 +789,8 @@ server.registerTool(
     try {
       const url = buildBearUrl('delete-tag', {
         name,
+        open_note: 'no',
+        new_window: 'no',
         show_window: 'no',
       });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -719,12 +719,14 @@ server.registerTool(
       name: z
         .string()
         .trim()
-        .min(1, 'Tag name is required')
+        .transform((v) => v.replace(/^#/, ''))
+        .pipe(z.string().min(1, 'Tag name is required'))
         .describe('Current tag name to rename (without # symbol)'),
       new_name: z
         .string()
         .trim()
-        .min(1, 'New tag name is required')
+        .transform((v) => v.replace(/^#/, ''))
+        .pipe(z.string().min(1, 'New tag name is required'))
         .describe(
           'New tag name (without # symbol). Use slashes for hierarchy, e.g., "archive/old-project"'
         ),
@@ -773,7 +775,8 @@ server.registerTool(
       name: z
         .string()
         .trim()
-        .min(1, 'Tag name is required')
+        .transform((v) => v.replace(/^#/, ''))
+        .pipe(z.string().min(1, 'Tag name is required'))
         .describe('Tag name to delete (without # symbol)'),
     },
     annotations: {

--- a/tests/system/tag-management.test.ts
+++ b/tests/system/tag-management.test.ts
@@ -15,41 +15,32 @@ const PAUSE_AFTER_WRITE_OP = 100; // ms to wait after write operations for Bear 
 
 const TAG_ORIGINAL = `stest-tag-mgmt-${RUN_ID}-original`;
 const TAG_RENAMED = `stest-tag-mgmt-${RUN_ID}-renamed`;
+const TAG_TO_DELETE = `stest-tag-mgmt-${RUN_ID}-to-delete`;
 
 const TAG_NESTED_ORIGINAL = `stest-tag-mgmt-${RUN_ID}/nested-original`;
 const TAG_NESTED_RENAMED = `stest-tag-mgmt-${RUN_ID}/nested-renamed`;
-
-const NOTE_TITLE = uniqueTitle(TEST_PREFIX, 'TagOps', RUN_ID);
-const NOTE_TITLE_NESTED = uniqueTitle(TEST_PREFIX, 'TagOpsNested', RUN_ID);
-
-let noteId: string | undefined;
-let nestedNoteId: string | undefined;
-
-beforeAll(() => {
-  callTool({
-    toolName: 'bear-create-note',
-    args: { title: NOTE_TITLE, text: 'Tag management test note', tags: TAG_ORIGINAL },
-  });
-  noteId = findNoteId(NOTE_TITLE);
-
-  callTool({
-    toolName: 'bear-create-note',
-    args: {
-      title: NOTE_TITLE_NESTED,
-      text: 'Hierarchical tag test note',
-      tags: TAG_NESTED_ORIGINAL,
-    },
-  });
-  nestedNoteId = findNoteId(NOTE_TITLE_NESTED);
-});
+const TAG_NESTED_TO_DELETE = `stest-tag-mgmt-${RUN_ID}/nested-to-delete`;
 
 afterAll(() => {
-  if (noteId) trashNote(noteId);
-  if (nestedNoteId) trashNote(nestedNoteId);
   cleanupTestNotes(TEST_PREFIX);
 });
 
 describe('bear-rename-tag via MCP Inspector CLI', () => {
+  const RENAME_NOTE_TITLE = uniqueTitle(TEST_PREFIX, 'Rename', RUN_ID);
+  let renameNoteId: string | undefined;
+
+  beforeAll(() => {
+    callTool({
+      toolName: 'bear-create-note',
+      args: { title: RENAME_NOTE_TITLE, text: 'Rename tag test note', tags: TAG_ORIGINAL },
+    });
+    renameNoteId = findNoteId(RENAME_NOTE_TITLE);
+  });
+
+  afterAll(() => {
+    if (renameNoteId) trashNote(renameNoteId);
+  });
+
   it('renames a tag across notes', async () => {
     const result = callTool({
       toolName: 'bear-rename-tag',
@@ -60,13 +51,12 @@ describe('bear-rename-tag via MCP Inspector CLI', () => {
 
     await sleep(PAUSE_AFTER_WRITE_OP);
 
-    // The note should now appear under the renamed tag
     const searchResult = callTool({
       toolName: 'bear-search-notes',
       args: { tag: TAG_RENAMED },
     });
 
-    expect(searchResult).toContain(NOTE_TITLE);
+    expect(searchResult).toContain(RENAME_NOTE_TITLE);
   });
 
   it('old tag no longer returns results', () => {
@@ -80,36 +70,68 @@ describe('bear-rename-tag via MCP Inspector CLI', () => {
 });
 
 describe('bear-delete-tag via MCP Inspector CLI', () => {
+  const DELETE_NOTE_TITLE = uniqueTitle(TEST_PREFIX, 'Delete', RUN_ID);
+  let deleteNoteId: string | undefined;
+
+  beforeAll(() => {
+    callTool({
+      toolName: 'bear-create-note',
+      args: { title: DELETE_NOTE_TITLE, text: 'Delete tag test note', tags: TAG_TO_DELETE },
+    });
+    deleteNoteId = findNoteId(DELETE_NOTE_TITLE);
+  });
+
+  afterAll(() => {
+    if (deleteNoteId) trashNote(deleteNoteId);
+  });
+
   it('removes a tag without affecting the note', async () => {
     const result = callTool({
       toolName: 'bear-delete-tag',
-      args: { name: TAG_RENAMED },
+      args: { name: TAG_TO_DELETE },
     });
 
     expect(result).toContain('deleted successfully');
 
     await sleep(PAUSE_AFTER_WRITE_OP);
 
-    // Tag should no longer return results
     const searchResult = callTool({
       toolName: 'bear-search-notes',
-      args: { tag: TAG_RENAMED },
+      args: { tag: TAG_TO_DELETE },
     });
 
     expect(searchResult).toContain('No notes found');
 
-    // The note itself should still exist
     const openResult = callTool({
       toolName: 'bear-open-note',
-      args: { id: noteId! },
+      args: { id: deleteNoteId! },
     });
 
-    expect(openResult).toContain(NOTE_TITLE);
+    expect(openResult).toContain(DELETE_NOTE_TITLE);
   });
 });
 
 // Slashes in tag names encode as %2F in URLs — exercises a different code path than flat tags
-describe('hierarchical tag operations via MCP Inspector CLI', () => {
+describe('hierarchical tag rename via MCP Inspector CLI', () => {
+  const NESTED_RENAME_TITLE = uniqueTitle(TEST_PREFIX, 'NestedRename', RUN_ID);
+  let nestedRenameNoteId: string | undefined;
+
+  beforeAll(() => {
+    callTool({
+      toolName: 'bear-create-note',
+      args: {
+        title: NESTED_RENAME_TITLE,
+        text: 'Hierarchical rename test',
+        tags: TAG_NESTED_ORIGINAL,
+      },
+    });
+    nestedRenameNoteId = findNoteId(NESTED_RENAME_TITLE);
+  });
+
+  afterAll(() => {
+    if (nestedRenameNoteId) trashNote(nestedRenameNoteId);
+  });
+
   it('renames a hierarchical tag', async () => {
     const result = callTool({
       toolName: 'bear-rename-tag',
@@ -125,13 +147,34 @@ describe('hierarchical tag operations via MCP Inspector CLI', () => {
       args: { tag: TAG_NESTED_RENAMED },
     });
 
-    expect(searchResult).toContain(NOTE_TITLE_NESTED);
+    expect(searchResult).toContain(NESTED_RENAME_TITLE);
+  });
+});
+
+describe('hierarchical tag delete via MCP Inspector CLI', () => {
+  const NESTED_DELETE_TITLE = uniqueTitle(TEST_PREFIX, 'NestedDelete', RUN_ID);
+  let nestedDeleteNoteId: string | undefined;
+
+  beforeAll(() => {
+    callTool({
+      toolName: 'bear-create-note',
+      args: {
+        title: NESTED_DELETE_TITLE,
+        text: 'Hierarchical delete test',
+        tags: TAG_NESTED_TO_DELETE,
+      },
+    });
+    nestedDeleteNoteId = findNoteId(NESTED_DELETE_TITLE);
+  });
+
+  afterAll(() => {
+    if (nestedDeleteNoteId) trashNote(nestedDeleteNoteId);
   });
 
   it('deletes a hierarchical tag without affecting the note', async () => {
     const result = callTool({
       toolName: 'bear-delete-tag',
-      args: { name: TAG_NESTED_RENAMED },
+      args: { name: TAG_NESTED_TO_DELETE },
     });
 
     expect(result).toContain('deleted successfully');
@@ -140,16 +183,49 @@ describe('hierarchical tag operations via MCP Inspector CLI', () => {
 
     const searchResult = callTool({
       toolName: 'bear-search-notes',
-      args: { tag: TAG_NESTED_RENAMED },
+      args: { tag: TAG_NESTED_TO_DELETE },
     });
 
     expect(searchResult).toContain('No notes found');
 
     const openResult = callTool({
       toolName: 'bear-open-note',
-      args: { id: nestedNoteId! },
+      args: { id: nestedDeleteNoteId! },
     });
 
-    expect(openResult).toContain(NOTE_TITLE_NESTED);
+    expect(openResult).toContain(NESTED_DELETE_TITLE);
+  });
+});
+
+describe('tag name # prefix stripping via MCP Inspector CLI', () => {
+  it('strips leading # from tag names in rename', async () => {
+    const TAG_HASH = `stest-tag-mgmt-${RUN_ID}-hash`;
+    const TAG_HASH_RENAMED = `stest-tag-mgmt-${RUN_ID}-hash-renamed`;
+    const hashTitle = uniqueTitle(TEST_PREFIX, 'HashTag', RUN_ID);
+
+    callTool({
+      toolName: 'bear-create-note',
+      args: { title: hashTitle, text: 'Hash prefix test', tags: TAG_HASH },
+    });
+    const hashNoteId = findNoteId(hashTitle);
+
+    try {
+      // Pass with # prefix — the schema transform should strip it
+      callTool({
+        toolName: 'bear-rename-tag',
+        args: { name: `#${TAG_HASH}`, new_name: `#${TAG_HASH_RENAMED}` },
+      });
+
+      await sleep(PAUSE_AFTER_WRITE_OP);
+
+      const searchResult = callTool({
+        toolName: 'bear-search-notes',
+        args: { tag: TAG_HASH_RENAMED },
+      });
+
+      expect(searchResult).toContain(hashTitle);
+    } finally {
+      if (hashNoteId) trashNote(hashNoteId);
+    }
   });
 });

--- a/tests/system/tag-management.test.ts
+++ b/tests/system/tag-management.test.ts
@@ -16,9 +16,14 @@ const PAUSE_AFTER_WRITE_OP = 100; // ms to wait after write operations for Bear 
 const TAG_ORIGINAL = `stest-tag-mgmt-${RUN_ID}-original`;
 const TAG_RENAMED = `stest-tag-mgmt-${RUN_ID}-renamed`;
 
+const TAG_NESTED_ORIGINAL = `stest-tag-mgmt-${RUN_ID}/nested-original`;
+const TAG_NESTED_RENAMED = `stest-tag-mgmt-${RUN_ID}/nested-renamed`;
+
 const NOTE_TITLE = uniqueTitle(TEST_PREFIX, 'TagOps', RUN_ID);
+const NOTE_TITLE_NESTED = uniqueTitle(TEST_PREFIX, 'TagOpsNested', RUN_ID);
 
 let noteId: string | undefined;
+let nestedNoteId: string | undefined;
 
 beforeAll(() => {
   callTool({
@@ -26,10 +31,21 @@ beforeAll(() => {
     args: { title: NOTE_TITLE, text: 'Tag management test note', tags: TAG_ORIGINAL },
   });
   noteId = findNoteId(NOTE_TITLE);
+
+  callTool({
+    toolName: 'bear-create-note',
+    args: {
+      title: NOTE_TITLE_NESTED,
+      text: 'Hierarchical tag test note',
+      tags: TAG_NESTED_ORIGINAL,
+    },
+  });
+  nestedNoteId = findNoteId(NOTE_TITLE_NESTED);
 });
 
 afterAll(() => {
   if (noteId) trashNote(noteId);
+  if (nestedNoteId) trashNote(nestedNoteId);
   cleanupTestNotes(TEST_PREFIX);
 });
 
@@ -89,5 +105,51 @@ describe('bear-delete-tag via MCP Inspector CLI', () => {
     });
 
     expect(openResult).toContain(NOTE_TITLE);
+  });
+});
+
+// Slashes in tag names encode as %2F in URLs — exercises a different code path than flat tags
+describe('hierarchical tag operations via MCP Inspector CLI', () => {
+  it('renames a hierarchical tag', async () => {
+    const result = callTool({
+      toolName: 'bear-rename-tag',
+      args: { name: TAG_NESTED_ORIGINAL, new_name: TAG_NESTED_RENAMED },
+    });
+
+    expect(result).toContain('renamed successfully');
+
+    await sleep(PAUSE_AFTER_WRITE_OP);
+
+    const searchResult = callTool({
+      toolName: 'bear-search-notes',
+      args: { tag: TAG_NESTED_RENAMED },
+    });
+
+    expect(searchResult).toContain(NOTE_TITLE_NESTED);
+  });
+
+  it('deletes a hierarchical tag without affecting the note', async () => {
+    const result = callTool({
+      toolName: 'bear-delete-tag',
+      args: { name: TAG_NESTED_RENAMED },
+    });
+
+    expect(result).toContain('deleted successfully');
+
+    await sleep(PAUSE_AFTER_WRITE_OP);
+
+    const searchResult = callTool({
+      toolName: 'bear-search-notes',
+      args: { tag: TAG_NESTED_RENAMED },
+    });
+
+    expect(searchResult).toContain('No notes found');
+
+    const openResult = callTool({
+      toolName: 'bear-open-note',
+      args: { id: nestedNoteId! },
+    });
+
+    expect(openResult).toContain(NOTE_TITLE_NESTED);
   });
 });

--- a/tests/system/tag-management.test.ts
+++ b/tests/system/tag-management.test.ts
@@ -1,0 +1,93 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  callTool,
+  cleanupTestNotes,
+  findNoteId,
+  sleep,
+  trashNote,
+  uniqueTitle,
+} from './inspector.js';
+
+const TEST_PREFIX = '[Bear-MCP-stest-tag-mgmt]';
+const RUN_ID = Date.now();
+const PAUSE_AFTER_WRITE_OP = 100; // ms to wait after write operations for Bear to process changes
+
+const TAG_ORIGINAL = `stest-tag-mgmt-${RUN_ID}-original`;
+const TAG_RENAMED = `stest-tag-mgmt-${RUN_ID}-renamed`;
+
+const NOTE_TITLE = uniqueTitle(TEST_PREFIX, 'TagOps', RUN_ID);
+
+let noteId: string | undefined;
+
+beforeAll(() => {
+  callTool({
+    toolName: 'bear-create-note',
+    args: { title: NOTE_TITLE, text: 'Tag management test note', tags: TAG_ORIGINAL },
+  });
+  noteId = findNoteId(NOTE_TITLE);
+});
+
+afterAll(() => {
+  if (noteId) trashNote(noteId);
+  cleanupTestNotes(TEST_PREFIX);
+});
+
+describe('bear-rename-tag via MCP Inspector CLI', () => {
+  it('renames a tag across notes', async () => {
+    const result = callTool({
+      toolName: 'bear-rename-tag',
+      args: { name: TAG_ORIGINAL, new_name: TAG_RENAMED },
+    });
+
+    expect(result).toContain('renamed successfully');
+
+    await sleep(PAUSE_AFTER_WRITE_OP);
+
+    // The note should now appear under the renamed tag
+    const searchResult = callTool({
+      toolName: 'bear-search-notes',
+      args: { tag: TAG_RENAMED },
+    });
+
+    expect(searchResult).toContain(NOTE_TITLE);
+  });
+
+  it('old tag no longer returns results', () => {
+    const searchResult = callTool({
+      toolName: 'bear-search-notes',
+      args: { tag: TAG_ORIGINAL },
+    });
+
+    expect(searchResult).toContain('No notes found');
+  });
+});
+
+describe('bear-delete-tag via MCP Inspector CLI', () => {
+  it('removes a tag without affecting the note', async () => {
+    const result = callTool({
+      toolName: 'bear-delete-tag',
+      args: { name: TAG_RENAMED },
+    });
+
+    expect(result).toContain('deleted successfully');
+
+    await sleep(PAUSE_AFTER_WRITE_OP);
+
+    // Tag should no longer return results
+    const searchResult = callTool({
+      toolName: 'bear-search-notes',
+      args: { tag: TAG_RENAMED },
+    });
+
+    expect(searchResult).toContain('No notes found');
+
+    // The note itself should still exist
+    const openResult = callTool({
+      toolName: 'bear-open-note',
+      args: { id: noteId! },
+    });
+
+    expect(openResult).toContain(NOTE_TITLE);
+  });
+});

--- a/tests/system/tag-management.test.ts
+++ b/tests/system/tag-management.test.ts
@@ -228,4 +228,34 @@ describe('tag name # prefix stripping via MCP Inspector CLI', () => {
       if (hashNoteId) trashNote(hashNoteId);
     }
   });
+
+  it('strips leading # from tag name in delete', async () => {
+    const TAG_HASH_DELETE = `stest-tag-mgmt-${RUN_ID}-hash-del`;
+    const hashDelTitle = uniqueTitle(TEST_PREFIX, 'HashTagDel', RUN_ID);
+
+    callTool({
+      toolName: 'bear-create-note',
+      args: { title: hashDelTitle, text: 'Hash prefix delete test', tags: TAG_HASH_DELETE },
+    });
+    const hashDelNoteId = findNoteId(hashDelTitle);
+
+    try {
+      // Pass with # prefix — the schema transform should strip it
+      callTool({
+        toolName: 'bear-delete-tag',
+        args: { name: `#${TAG_HASH_DELETE}` },
+      });
+
+      await sleep(PAUSE_AFTER_WRITE_OP);
+
+      const searchResult = callTool({
+        toolName: 'bear-search-notes',
+        args: { tag: TAG_HASH_DELETE },
+      });
+
+      expect(searchResult).toContain('No notes found');
+    } finally {
+      if (hashDelNoteId) trashNote(hashDelNoteId);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Adds two new MCP tools for Bear tag taxonomy management: `bear-rename-tag` and `bear-delete-tag`
- `bear-rename-tag` renames a tag across all notes using Bear's native `rename-tag` x-callback-url action
- `bear-delete-tag` removes a tag from all notes without affecting the notes themselves, using Bear's native `delete-tag` x-callback-url action
- Both tools follow the established fire-and-forget pattern (`buildBearUrl` → `executeBearXCallbackApi` → confirmation response), consistent with existing tools like `bear-archive-note` and `bear-add-tag`

## Why
Use case: manage tag taxonomy directly through MCP — rename tags to restructure organization or delete obsolete tags without manually editing every note.

--
Closes #63, closes #64

Created with Claude Code under the supervision of Serhii Vasylenko