### PR TITLE
feat: open note by title

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import { APP_VERSION, ENABLE_CONTENT_REPLACEMENT, ENABLE_NEW_NOTE_CONVENTIONS } from './config.js';
 import { applyNoteConventions } from './note-conventions.js';
 import { cleanBase64, createToolResponse, handleNoteTextUpdate, logger } from './utils.js';
-import { awaitNoteCreation, getNoteContent, searchNotes } from './notes.js';
+import { awaitNoteCreation, findNotesByTitle, getNoteContent, searchNotes } from './notes.js';
 import { findUntaggedNotes, listTags } from './tags.js';
 import { buildBearUrl, executeBearXCallbackApi } from './bear-urls.js';
 import type { BearTag } from './types.js';
@@ -35,13 +35,22 @@ server.registerTool(
   {
     title: 'Open Bear Note',
     description:
-      'Read the full text content of a Bear note from your library. Always includes text extracted from attached images and PDFs (aka OCR search) with clear labeling.',
+      'Read the full text content of a Bear note by its ID or title. Supports direct title lookup as an alternative to searching first. Always includes text extracted from attached images and PDFs (aka OCR search) with clear labeling.',
     inputSchema: {
       id: z
         .string()
         .trim()
-        .min(1, 'Note ID is required')
-        .describe('Exact note identifier (ID) obtained from bear-search-notes'),
+        .optional()
+        .describe(
+          'Note identifier (ID) from bear-search-notes. Either id or title must be provided.'
+        ),
+      title: z
+        .string()
+        .trim()
+        .optional()
+        .describe(
+          'Exact note title for direct lookup (case-insensitive). Either id or title must be provided. If multiple notes share the same title, returns a list for disambiguation.'
+        ),
     },
     annotations: {
       readOnlyHint: true,
@@ -49,11 +58,48 @@ server.registerTool(
       openWorldHint: false,
     },
   },
-  async ({ id }): Promise<CallToolResult> => {
-    logger.info(`bear-open-note called with id: ${id}, includeFiles: always`);
+  async ({ id, title }): Promise<CallToolResult> => {
+    logger.info(
+      `bear-open-note called with id: ${id || 'none'}, title: ${title ? '"' + title + '"' : 'none'}`
+    );
+
+    if (!id && !title) {
+      throw new Error(
+        'Either note ID or title is required. Use bear-search-notes to find the note ID, or provide the exact title.'
+      );
+    }
 
     try {
-      const noteWithContent = getNoteContent(id);
+      // Title lookup path: find by title, then fetch full content
+      if (!id && title) {
+        const matches = findNotesByTitle(title);
+
+        if (matches.length === 0) {
+          return createToolResponse(`No note found with title "${title}". The note may have been deleted, archived, or the title may be different.
+
+Use bear-search-notes to find the correct note.`);
+        }
+
+        if (matches.length > 1) {
+          const matchList = matches
+            .map(
+              (m, i) =>
+                `${i + 1}. ID: ${m.identifier} (modified: ${new Date(m.modification_date).toLocaleDateString()})`
+            )
+            .join('\n');
+
+          return createToolResponse(`Multiple notes found with title "${title}":
+
+${matchList}
+
+Use bear-open-note with a specific ID to open the desired note.`);
+        }
+
+        // Exactly one match — fetch full content by ID
+        id = matches[0].identifier;
+      }
+
+      const noteWithContent = getNoteContent(id!);
 
       if (!noteWithContent) {
         return createToolResponse(`Note with ID '${id}' not found. The note may have been deleted, archived, or the ID may be incorrect.

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -1,6 +1,6 @@
 import { setTimeout } from 'node:timers/promises';
 
-import type { BearNote, DateFilter } from './types.js';
+import type { BearNote, DateFilter, NoteTitleMatch } from './types.js';
 import { DEFAULT_SEARCH_LIMIT } from './config.js';
 import {
   convertCoreDataTimestamp,
@@ -155,6 +155,65 @@ export function getNoteContent(identifier: string): BearNote | null {
     closeBearDatabase(db);
   }
   return null;
+}
+
+/**
+ * Finds Bear notes matching an exact title (case-insensitive).
+ * Returns lightweight match objects for disambiguation — call getNoteContent()
+ * with the chosen identifier to retrieve the full note.
+ *
+ * @param title - The exact note title to match
+ * @returns Array of matching notes (empty if none found)
+ * @throws Error if database access fails
+ */
+export function findNotesByTitle(title: string): NoteTitleMatch[] {
+  logger.info(`findNotesByTitle called with title: "${title}"`);
+
+  if (!title || typeof title !== 'string' || !title.trim()) {
+    logAndThrow('Search error: Invalid note title provided');
+  }
+
+  const db = openBearDatabase();
+
+  try {
+    const query = `
+      SELECT ZTITLE as title,
+             ZUNIQUEIDENTIFIER as identifier,
+             ZMODIFICATIONDATE as modificationDate
+      FROM ZSFNOTE
+      WHERE LOWER(ZTITLE) = LOWER(?)
+        AND ZARCHIVED = 0
+        AND ZTRASHED = 0
+        AND ZENCRYPTED = 0
+      ORDER BY ZMODIFICATIONDATE DESC
+    `;
+    const stmt = db.prepare(query);
+    const rows = stmt.all(title.trim());
+
+    if (!rows || rows.length === 0) {
+      logger.info(`No notes found with title: "${title}"`);
+      return [];
+    }
+
+    logger.info(`Found ${rows.length} note(s) with title: "${title}"`);
+
+    return rows.map((row) => {
+      const r = row as Record<string, unknown>;
+      return {
+        identifier: r.identifier as string,
+        title: (r.title as string) || 'Untitled',
+        modification_date: convertCoreDataTimestamp(r.modificationDate as number),
+      };
+    });
+  } catch (error) {
+    logAndThrow(
+      `Database error: Failed to find notes by title: ${error instanceof Error ? error.message : String(error)}`
+    );
+  } finally {
+    closeBearDatabase(db);
+  }
+
+  return [];
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,16 @@ export interface BearNote {
 }
 
 /**
+ * Lightweight note match for title-based lookups where full content is not needed.
+ * Used for disambiguation when multiple notes share the same title.
+ */
+export interface NoteTitleMatch {
+  identifier: string;
+  title: string;
+  modification_date: string;
+}
+
+/**
  * Date filter parameters for searching notes by creation or modification date.
  */
 export interface DateFilter {

--- a/tests/system/open-note-by-title.test.ts
+++ b/tests/system/open-note-by-title.test.ts
@@ -1,0 +1,114 @@
+import { afterAll, describe, expect, it } from 'vitest';
+
+import {
+  callTool,
+  cleanupTestNotes,
+  extractNoteBody,
+  trashNote,
+  tryExtractNoteId,
+  uniqueTitle,
+} from './inspector.js';
+
+const TEST_PREFIX = '[Bear-MCP-stest-open-by-title]';
+const RUN_ID = Date.now();
+
+function title(label: string): string {
+  return uniqueTitle(TEST_PREFIX, label, RUN_ID);
+}
+
+afterAll(() => {
+  cleanupTestNotes(TEST_PREFIX);
+});
+
+describe('bear-open-note by title', () => {
+  it('opens a note by exact title', () => {
+    const noteTitle = title('Unique');
+    const noteText = 'Content for open-by-title test';
+    let noteId: string | undefined;
+
+    try {
+      const createResult = callTool({
+        toolName: 'bear-create-note',
+        args: { title: noteTitle, text: noteText },
+      });
+      noteId = tryExtractNoteId(createResult) ?? undefined;
+
+      const openResult = callTool({
+        toolName: 'bear-open-note',
+        args: { title: noteTitle },
+      });
+
+      expect(openResult).toContain(noteTitle);
+      expect(extractNoteBody(openResult)).toContain(noteText);
+      // Response must include the note ID for follow-up operations
+      expect(tryExtractNoteId(openResult)).toBeTruthy();
+    } finally {
+      if (noteId) trashNote(noteId);
+    }
+  });
+
+  it('title matching is case-insensitive', () => {
+    const noteTitle = title('CaseTest');
+    let noteId: string | undefined;
+
+    try {
+      const createResult = callTool({
+        toolName: 'bear-create-note',
+        args: { title: noteTitle, text: 'Case sensitivity test' },
+      });
+      noteId = tryExtractNoteId(createResult) ?? undefined;
+
+      const openResult = callTool({
+        toolName: 'bear-open-note',
+        args: { title: noteTitle.toLowerCase() },
+      });
+
+      expect(openResult).toContain(noteTitle);
+    } finally {
+      if (noteId) trashNote(noteId);
+    }
+  });
+
+  it('returns not-found error for non-existent title', () => {
+    const openResult = callTool({
+      toolName: 'bear-open-note',
+      args: { title: `Non-existent note ${RUN_ID}` },
+    });
+
+    expect(openResult).toContain('No note found with title');
+  });
+
+  it('returns disambiguation list when multiple notes share the same title', () => {
+    const sharedTitle = title('Duplicate');
+    const noteIds: string[] = [];
+
+    try {
+      // Create two notes with the same title
+      for (const text of ['First duplicate', 'Second duplicate']) {
+        const createResult = callTool({
+          toolName: 'bear-create-note',
+          args: { title: sharedTitle, text },
+        });
+        const id = tryExtractNoteId(createResult);
+        if (id) noteIds.push(id);
+      }
+
+      expect(noteIds.length).toBe(2);
+
+      const openResult = callTool({
+        toolName: 'bear-open-note',
+        args: { title: sharedTitle },
+      });
+
+      expect(openResult).toContain('Multiple notes found');
+      // Both IDs should appear in the disambiguation list
+      for (const id of noteIds) {
+        expect(openResult).toContain(id);
+      }
+    } finally {
+      for (const id of noteIds) {
+        trashNote(id);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds optional `title` parameter to `bear-open-note` as an alternative to `id`
- When a unique note matches the title (case-insensitive), returns its full content identically to lookup by ID
- When multiple notes share the same title, returns an error listing matching note IDs and modification dates for disambiguation
- When no note matches, returns a clear "not found" error

## Why
Saves a round-trip when the user knows the exact title -- instead of "search for X, pick from results, open by ID", they can directly say "show me the note titled Meeting Notes".

--
Closes #60

Created with Claude Code under the supervision of Serhii Vasylenko