### PR TITLE
feat: add file_path parameter to bear-add-file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`bear-add-file` accepts `file_path` as alternative to `base64_content`** ([#88](https://github.com/vasylenko/bear-notes-mcp/issues/88)): When the file exists on disk, provide its path instead of base64-encoded content. The server reads and encodes the file internally, avoiding the cost of the LLM producing thousands of base64 output tokens. The `filename` parameter is auto-inferred from the path when omitted. The two input modes (`file_path` and `base64_content`) are mutually exclusive.
+
 ### Changed
 - **`bear-open-note` accepts title as an alternative to ID** ([#60](https://github.com/vasylenko/bear-notes-mcp/issues/60)): The tool now takes an optional `title` parameter, so AI agents can open a note by its exact title without needing to know the ID upfront. Title matching is case-insensitive. When multiple notes share the same title, the tool returns a disambiguation list with each note's ID and last modification date instead of picking one arbitrarily. When no match is found, the response suggests using `bear-search-notes` for partial text search.
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Add to your MCP configuration file:
 - **`bear-search-notes`** - Find notes by searching text content, filtering by tags, or date ranges. Includes OCR search in attachments
 - **`bear-add-text`** - Insert text at the beginning or end of a Bear note, or within a specific section identified by its header
 - **`bear-replace-text`** - Replace content in an existing Bear note — either the full body or a specific section. Requires content replacement to be enabled in settings.
-- **`bear-add-file`** - Attach a file (image, PDF, Excel, etc.) to an existing Bear note using base64-encoded content
+- **`bear-add-file`** - Attach a file to an existing Bear note. Provide a local file path (preferred) or base64-encoded content.
 - **`bear-list-tags`** - List all tags in your Bear library as a hierarchical tree with note counts
 - **`bear-find-untagged-notes`** - Find notes in your Bear library that have no tags assigned
 - **`bear-add-tag`** - Add one or more tags to an existing Bear note

--- a/docs/NPM.md
+++ b/docs/NPM.md
@@ -21,7 +21,7 @@ Search, read, create, and update your Bear Notes from any AI assistant.
 - **`bear-search-notes`** - Find notes by searching text content, filtering by tags, or date ranges. Includes OCR search in attachments
 - **`bear-add-text`** - Insert text at the beginning or end of a Bear note, or within a specific section identified by its header
 - **`bear-replace-text`** - Replace content in an existing Bear note — either the full body or a specific section. Requires content replacement to be enabled in settings.
-- **`bear-add-file`** - Attach a file (image, PDF, Excel, etc.) to an existing Bear note using base64-encoded content
+- **`bear-add-file`** - Attach a file to an existing Bear note. Provide a local file path (preferred) or base64-encoded content.
 - **`bear-list-tags`** - List all tags in your Bear library as a hierarchical tree with note counts
 - **`bear-find-untagged-notes`** - Find notes in your Bear library that have no tags assigned
 - **`bear-add-tag`** - Add one or more tags to an existing Bear note

--- a/manifest.json
+++ b/manifest.json
@@ -80,7 +80,7 @@
     },
     {
       "name": "bear-add-file",
-      "description": "Attach a file (image, PDF, Excel, etc.) to an existing Bear note using base64-encoded content"
+      "description": "Attach a file to an existing Bear note. Provide a local file path (preferred) or base64-encoded content."
     },
     {
       "name": "bear-list-tags",

--- a/src/main.ts
+++ b/src/main.ts
@@ -504,7 +504,7 @@ server.registerTool(
     );
 
     if (!id && !title) {
-      throw new Error(
+      return createToolResponse(
         'Either note ID or title is required. Use bear-search-notes to find the note ID.'
       );
     }
@@ -527,6 +527,9 @@ server.registerTool(
         // Read file from disk and encode — avoids the LLM producing thousands of base64 tokens
         try {
           const buffer = readFileSync(file_path);
+          if (buffer.length === 0) {
+            return createToolResponse(`File is empty: ${file_path}`);
+          }
           fileData = buffer.toString('base64');
         } catch (err) {
           const code = (err as { code?: string }).code;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { basename } from 'node:path';
+
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
@@ -455,18 +458,32 @@ server.registerTool(
   {
     title: 'Add File to Note',
     description:
-      'Attach a file to an existing Bear note. Encode the file to base64 using shell commands (e.g., base64 /path/to/file.xlsx) and provide the encoded content. Use bear-search-notes first to get the note ID.',
+      'Attach a file to an existing Bear note. Preferred: provide file_path for files on disk — the server reads and encodes them automatically. Alternative: provide base64_content with pre-encoded data. Use bear-search-notes first to get the note ID.',
     inputSchema: {
+      file_path: z
+        .string()
+        .trim()
+        .min(1)
+        .optional()
+        .describe(
+          'Absolute path to a file on disk. Preferred over base64_content when the file already exists locally.'
+        ),
       base64_content: z
         .string()
         .trim()
-        .min(1, 'Base64 file content is required')
-        .describe('Base64-encoded file content'),
+        .min(1)
+        .optional()
+        .describe(
+          'Base64-encoded file content. Use file_path instead when the file exists on disk.'
+        ),
       filename: z
         .string()
         .trim()
-        .min(1, 'Filename is required')
-        .describe('Filename with extension (e.g., budget.xlsx, report.pdf)'),
+        .min(1)
+        .optional()
+        .describe(
+          'Filename with extension (e.g., budget.xlsx, report.pdf). Required when using base64_content. Auto-inferred from file_path when omitted.'
+        ),
       id: z
         .string()
         .trim()
@@ -481,9 +498,9 @@ server.registerTool(
       openWorldHint: true,
     },
   },
-  async ({ base64_content, filename, id, title }): Promise<CallToolResult> => {
+  async ({ file_path, base64_content, filename, id, title }): Promise<CallToolResult> => {
     logger.info(
-      `bear-add-file called with base64_content: ${base64_content ? 'provided' : 'none'}, filename: ${filename || 'none'}, id: ${id || 'none'}, title: ${title || 'none'}`
+      `bear-add-file called with file_path: ${file_path || 'none'}, base64_content: ${base64_content ? 'provided' : 'none'}, filename: ${filename || 'none'}, id: ${id || 'none'}, title: ${title || 'none'}`
     );
 
     if (!id && !title) {
@@ -492,9 +509,43 @@ server.registerTool(
       );
     }
 
+    if (file_path && base64_content) {
+      return createToolResponse('Provide either file_path or base64_content, not both.');
+    }
+    if (!file_path && !base64_content) {
+      return createToolResponse('Either file_path or base64_content is required.');
+    }
+    if (base64_content && !filename) {
+      return createToolResponse('filename is required when using base64_content.');
+    }
+
     try {
-      // base64 CLI adds line breaks that break URL encoding
-      const cleanedBase64 = cleanBase64(base64_content);
+      let fileData: string;
+      let resolvedFilename: string;
+
+      if (file_path) {
+        // Read file from disk and encode — avoids the LLM producing thousands of base64 tokens
+        try {
+          const buffer = readFileSync(file_path);
+          fileData = buffer.toString('base64');
+        } catch (err) {
+          const code = (err as { code?: string }).code;
+          if (code === 'ENOENT') {
+            return createToolResponse(`File not found: ${file_path}`);
+          }
+          if (code === 'EACCES') {
+            return createToolResponse(`Permission denied: ${file_path}`);
+          }
+          return createToolResponse(
+            `Cannot read file: ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+        resolvedFilename = filename || basename(file_path);
+      } else {
+        // base64_content path — strip whitespace that base64 CLI adds
+        fileData = cleanBase64(base64_content!);
+        resolvedFilename = filename!;
+      }
 
       // Fail fast with helpful message rather than cryptic Bear error
       if (id) {
@@ -509,17 +560,17 @@ Use bear-search-notes to find the correct note identifier.`);
       const url = buildBearUrl('add-file', {
         id,
         title,
-        file: cleanedBase64,
-        filename,
+        file: fileData,
+        filename: resolvedFilename,
         mode: 'append',
       });
 
-      logger.debug(`Executing Bear add-file URL for: ${filename}`);
+      logger.debug(`Executing Bear add-file URL for: ${resolvedFilename}`);
       await executeBearXCallbackApi(url);
 
       const noteIdentifier = id ? `Note ID: ${id}` : `Note title: "${title!}"`;
 
-      return createToolResponse(`File "${filename}" added successfully!
+      return createToolResponse(`File "${resolvedFilename}" added successfully!
 
 ${noteIdentifier}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -466,7 +466,7 @@ server.registerTool(
         .min(1)
         .optional()
         .describe(
-          'Absolute path to a file on disk. Preferred over base64_content when the file already exists locally.'
+          'Path to a file on disk. Preferred over base64_content when the file already exists locally.'
         ),
       base64_content: z
         .string()

--- a/tests/system/attached-files.test.ts
+++ b/tests/system/attached-files.test.ts
@@ -33,6 +33,9 @@ const HTML_BASE64 = 'PGh0bWw+PGJvZHk+PHA+QmVhciBjYW5ub3QgT0NSIHRoaXM8L3A+PC9ib2R
 const TINY_PNG_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
 
+// Absolute path to fixture — used for file_path tests
+const OCR_JPG_PATH = resolve(import.meta.dirname, '../fixtures/ocr-text.jpg');
+
 afterAll(() => {
   cleanupTestNotes(TEST_PREFIX);
 });
@@ -252,6 +255,87 @@ describe('attached files content separation', () => {
       // reference is removed from the note body — the attachment is not orphaned
       expect(afterResponse.content).toHaveLength(2);
       expect(afterResponse.content[1].text).toContain('architecture.png');
+    } finally {
+      if (noteId) trashNote(noteId);
+    }
+  });
+
+  it('attaches file via file_path', async () => {
+    const title = uniqueTitle(TEST_PREFIX, 'FilePath', RUN_ID);
+    let noteId: string | undefined;
+
+    try {
+      callTool({
+        toolName: 'bear-create-note',
+        args: { title, text: 'File path attachment test', tags: 'system-test' },
+      });
+
+      noteId = findNoteId(title);
+
+      const addResult = callTool({
+        toolName: 'bear-add-file',
+        args: { id: noteId, file_path: OCR_JPG_PATH },
+      }).content[0].text;
+
+      // Server should infer filename from path
+      expect(addResult).toContain('ocr-text.jpg');
+      expect(addResult).toContain('added successfully');
+
+      // Poll until Bear finishes OCR — proves the file was actually attached
+      const response = await waitForFileContent(noteId, 'simple');
+      expect(response.content).toHaveLength(2);
+      expect(response.content[1].text).toContain('ocr-text.jpg');
+    } finally {
+      if (noteId) trashNote(noteId);
+    }
+  });
+
+  it('file_path uses explicit filename when provided', async () => {
+    const title = uniqueTitle(TEST_PREFIX, 'FilePathCustomName', RUN_ID);
+    let noteId: string | undefined;
+
+    try {
+      callTool({
+        toolName: 'bear-create-note',
+        args: { title, text: 'Custom filename test', tags: 'system-test' },
+      });
+
+      noteId = findNoteId(title);
+
+      const addResult = callTool({
+        toolName: 'bear-add-file',
+        args: { id: noteId, file_path: OCR_JPG_PATH, filename: 'custom-name.jpg' },
+      }).content[0].text;
+
+      expect(addResult).toContain('custom-name.jpg');
+      expect(addResult).toContain('added successfully');
+
+      const response = await waitForFileContent(noteId, 'custom-name.jpg');
+      expect(response.content).toHaveLength(2);
+      expect(response.content[1].text).toContain('custom-name.jpg');
+    } finally {
+      if (noteId) trashNote(noteId);
+    }
+  });
+
+  it('returns error for non-existent file_path', () => {
+    const title = uniqueTitle(TEST_PREFIX, 'BadPath', RUN_ID);
+    let noteId: string | undefined;
+
+    try {
+      callTool({
+        toolName: 'bear-create-note',
+        args: { title, text: 'Bad path test', tags: 'system-test' },
+      });
+
+      noteId = findNoteId(title);
+
+      const result = callTool({
+        toolName: 'bear-add-file',
+        args: { id: noteId, file_path: '/tmp/does-not-exist-12345.pdf' },
+      }).content[0].text;
+
+      expect(result).toContain('File not found');
     } finally {
       if (noteId) trashNote(noteId);
     }


### PR DESCRIPTION
## Summary

- Adds `file_path` parameter to `bear-add-file` as an alternative to `base64_content` — when a file exists on disk, the server reads and encodes it internally
- When `file_path` is provided, `filename` is auto-inferred from the path; explicit `filename` overrides the inference
- When `base64_content` is provided, existing behavior is preserved — `filename` is required
- The two input modes are mutually exclusive; empty files and missing files return clear error messages
- Tool description updated across manifest.json, README, and NPM docs to present `file_path` as the preferred method

## Why

LLMs attaching files via `base64_content` must produce the entire file as output tokens — a 65KB JPEG becomes ~88,000 tokens of base64 character by character. This is slow (minutes vs seconds), expensive, and often forces quality degradation. Since this MCP server runs locally on the same machine, it can read files from disk directly.

--
Closes #88

Created with Claude Code under the supervision of Serhii Vasylenko