### PR TITLE
docs: Add Claude Code & Cowork plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Bear Notes MCP Server
 
-Search, read, create, and update your Bear Notes from any AI assistant. Available as a one-click **Claude Desktop extension** and as a standalone **npm package** for any MCP client.
+Search, read, create, and update your Bear Notes from any AI assistant. Available as a one-click **Claude Desktop extension**, a **Claude Code & Cowork plugin**, and as a standalone **npm package** for any MCP client.
 
 This **local-only** MCP server reads Bear's SQLite database for fast search with OCR support, and uses Bear's native API for writes. Complete privacy: no external connections, all processing on your Mac.
 
@@ -48,13 +48,30 @@ Example prompts:
 
 Ask Claude to search your Bear notes with a query like "Search my Bear notes for 'meeting'" - you should see your notes appear in the response!
 
+### Claude Code & Cowork Plugin
+
+Use Bear Notes as a full plugin in Claude Code or Cowork — includes best-practice skills, a setup wizard, and configuration via plugin settings.
+
+**Prerequisites**: [Bear app](https://bear.app/) must be installed, Node.js 24.13.0+
+
+```bash
+claude --plugin-dir /path/to/bear-notes-plugin
+```
+
+The plugin bundles this MCP server with:
+- **Bear Notes skill** — search strategy, section targeting, tag conventions, verify-after-write patterns, and safety guidance
+- **Setup skill** — run `/bear-notes:setup` to verify your environment and configure options
+- **Plugin settings** — debug logging, new note convention, and content replacement toggle managed through Claude's plugin UI
+
+See the [bear-notes-plugin](../bear-notes-plugin/) directory for the full plugin source.
+
 ### Standalone MCP Server
 
-Want to use this Bear Notes MCP server with Claude Code, Cursor, Codex, or other AI assistants?
+Want to use this Bear Notes MCP server with Cursor, Codex, or other AI assistants?
 
 **Requirements**: Node.js 24.13.0+
 
-#### Claude Code (one command)
+#### Claude Code (standalone, without plugin)
 
 ```bash
 claude mcp add bear-notes --transport stdio -- npx -y bear-notes-mcp@latest
@@ -100,6 +117,7 @@ Add to your MCP configuration file:
 Enable verbose logging for troubleshooting.
 
 - **Claude Desktop**: Settings → Extensions → Configure (next to Bear Notes) → toggle "Debug Logging" → Save → Restart Claude
+- **Claude Code/Cowork plugin**: set `debug` to `true` in plugin settings
 - **Standalone MCP server**: set environment variable `UI_DEBUG_TOGGLE=true`
 
 ### New Note Convention
@@ -126,6 +144,7 @@ By default, Bear places tags at the bottom of a note when created via API. Enabl
 > This convention is **disabled by default** — it's opt-in so existing behavior is preserved.
 
 - **Claude Desktop**: Settings → Extensions → Configure (next to Bear Notes) → toggle "New Note Convention" → Save → Restart Claude
+- **Claude Code/Cowork plugin**: set `enable_new_note_convention` to `true` in plugin settings
 - **Standalone MCP server**: set environment variable `UI_ENABLE_NEW_NOTE_CONVENTION=true`
 
 Example standalone configuration with the convention enabled:
@@ -151,6 +170,7 @@ Enable the `bear-replace-text` tool to replace content in existing notes — eit
 > This feature is **disabled by default** — it's opt-in because replacement is a destructive operation.
 
 - **Claude Desktop**: Settings → Extensions → Configure (next to Bear Notes) → toggle "Content Replacement" → Save → Restart Claude
+- **Claude Code/Cowork plugin**: set `enable_content_replacement` to `true` in plugin settings
 - **Standalone MCP server**: set environment variable `UI_ENABLE_CONTENT_REPLACEMENT=true`
 
 Example standalone configuration with content replacement enabled:

--- a/docs/conversion/CONVERSION_OVERVIEW.md
+++ b/docs/conversion/CONVERSION_OVERVIEW.md
@@ -1,0 +1,139 @@
+# Bear Notes MCP to Claude Plugin: Research Findings and Conversion Plan
+
+## Terminology Demystified
+
+There are three distinct layers in the Claude ecosystem, and they are **not interchangeable**:
+
+- **MCP (Model Context Protocol)** -- The underlying open protocol/plumbing. Still very much alive and central. Anthropic has NOT moved away from it; they've built higher-level abstractions on top of it.
+- **Skills** -- Markdown files (`SKILL.md`) with instructions that Claude dynamically loads. **No runtime code execution for external system access.** Think of them as reusable prompt templates. They cannot read databases, call APIs, or interact with local apps.
+- **Connectors** -- MCP-powered connections to external tools and data. This is the user-facing term for what an MCP server provides. Bear Notes MCP is a connector.
+- **Plugins** -- The distribution unit that bundles **all of the above** together: skills + MCP connectors + slash commands + sub-agents. Plugins work in both **Claude Code** and **Cowork**.
+
+```mermaid
+graph TD
+    Plugin["Plugin (distribution package)"]
+    Plugin --> Skills["Skills (SKILL.md)<br/>Markdown instructions"]
+    Plugin --> MCP["MCP Connector (.mcp.json)<br/>External tool access"]
+    Plugin --> Slash["Slash Commands<br/>User-triggered workflows"]
+    Plugin --> Agents["Sub-agents<br/>Parallel task delegation"]
+    MCP --> BearDB["Bear SQLite DB"]
+    MCP --> BearAPI["Bear x-callback-url API"]
+```
+
+## What bear-notes-mcp Currently Is
+
+The bear-notes-mcp codebase is an **MCP server** (a connector) distributed two ways:
+
+- As an **MCPB** (MCP Bundle / `.mcpb`) for Claude Desktop one-click install
+- As an **npm package** for Claude Code, Cursor, Codex, etc.
+
+It provides 12 MCP tools that read Bear's SQLite database directly (for search/read) and use Bear's x-callback-url API (for writes). This requires **runtime code execution** — Node.js reading a local SQLite file, executing URL schemes on macOS.
+
+## Why It CANNOT Be "Just a Skill"
+
+A skill is a markdown file with instructions. It has no ability to:
+
+- Open and query a SQLite database
+- Execute x-callback-url commands
+- Interact with local filesystem paths
+- Run any code against external systems
+
+If you tried to make bear-notes-mcp a pure skill, Claude would **hallucinate** note content rather than reading real data. Skills are for teaching Claude *how* to do something, not for giving Claude *access* to something.
+
+## What It SHOULD Become: A Plugin
+
+A **plugin** is the correct target. It bundles the MCP connector (the current server code) with skills, slash commands, and sub-agents into a single installable package that works in **both Claude Code and Cowork**.
+
+### Current Project Structure
+
+```
+bear-notes-mcp/
+├── src/main.ts              # MCP server entry point (12 tools)
+├── src/database.ts          # SQLite database connection
+├── src/notes.ts             # Note operations (search, content)
+├── src/tags.ts              # Tag operations (list, hierarchy)
+├── src/bear-urls.ts         # Bear x-callback-url handlers
+├── manifest.json            # MCPB manifest (Claude Desktop extension)
+├── package.json             # npm package config
+└── .mcp.json                # Local dev MCP config
+```
+
+### Target Plugin Structure
+
+```
+bear-notes-plugin/
+├── .claude-plugin/
+│   └── plugin.json          # Plugin manifest (name, version, author, userConfig)
+├── skills/
+│   └── bear-notes/
+│       └── SKILL.md         # Instructions for how to use Bear Notes effectively
+├── commands/
+│   ├── search.md            # /bear-notes:search slash command
+│   ├── create.md            # /bear-notes:create slash command
+│   └── organize.md          # /bear-notes:organize slash command
+├── agents/
+│   └── note-curator.md      # Sub-agent for complex note management workflows
+├── .mcp.json                # MCP server config (points to npm package)
+├── README.md
+└── CHANGELOG.md
+```
+
+### Key Files to Create
+
+**`.claude-plugin/plugin.json`** -- Plugin manifest with `userConfig` for debug logging, note conventions, and content replacement toggles (mirroring the current MCPB `user_config`).
+
+**`.mcp.json`** -- Bundles the existing MCP server via npm:
+
+```json
+{
+  "mcpServers": {
+    "bear-notes": {
+      "command": "npx",
+      "args": ["-y", "bear-notes-mcp@latest"],
+      "env": {
+        "UI_DEBUG_TOGGLE": "${user_config.debug}",
+        "UI_ENABLE_NEW_NOTE_CONVENTION": "${user_config.enable_new_note_convention}",
+        "UI_ENABLE_CONTENT_REPLACEMENT": "${user_config.enable_content_replacement}"
+      }
+    }
+  }
+}
+```
+
+**`skills/bear-notes/SKILL.md`** -- Teaching Claude best practices for working with Bear Notes: when to search vs. open by title, how to structure notes with headers for section-level operations, tag hierarchy conventions, etc.
+
+**`commands/`** -- Slash commands like `/bear-notes:search`, `/bear-notes:create`, `/bear-notes:organize` that provide structured workflows.
+
+**`agents/note-curator.md`** -- A sub-agent that can handle multi-step note organization workflows in parallel (e.g., "organize all untagged notes" or "merge duplicate notes").
+
+## Platform Compatibility
+
+| Platform        | Plugin Support           | How It Works                                        |
+| --------------- | ------------------------ | --------------------------------------------------- |
+| Claude Code     | Full support             | Install via marketplace or `--plugin-dir`           |
+| Claude Cowork   | Full support             | Plugins extend agentic multi-step workflows         |
+| Claude Desktop  | Via MCPB only            | Keep existing `.mcpb` distribution alongside plugin |
+| Claude.ai (web) | Via Connectors Directory | Submit MCP server as a remote connector             |
+
+## Existing Reference: The `zen` Plugin
+
+The [dailyzen-skill](https://github.com/kropdx/dailyzen-skill) plugin follows the correct plugin structure with `.claude-plugin/plugin.json`, `skills/zen/SKILL.md`, and `scripts/`. The bear-notes plugin would follow the same pattern but add an `.mcp.json` for the connector.
+
+## Implementation Approach
+
+The MCP server code (`bear-notes-mcp` npm package) stays as-is — it's already well-built. The plugin is a **wrapper** that bundles the MCP server with skills, commands, and agents. This means:
+
+- No changes to the existing MCP server codebase
+- The plugin references the npm package via `.mcp.json`
+- Skills, commands, and agents are new markdown files layered on top
+- Both distribution channels (MCPB for Desktop, Plugin for Code/Cowork) can coexist
+
+## Summary
+
+| Question                        | Answer                                                                             |
+| ------------------------------- | ---------------------------------------------------------------------------------- |
+| Is bear-notes-mcp a skill?      | No. It is a connector (MCP server).                                                |
+| Can it become "just a skill"?   | No. Skills cannot access databases or local APIs.                                  |
+| Does it need to be a connector? | Yes. The MCP server is the connector layer.                                        |
+| What should it become?          | A **plugin** that bundles the connector + skills + commands + agents.               |
+| Does MCP go away?               | No. MCP is the foundation. Connectors, plugins, and skills are built on top of it. |

--- a/docs/conversion/PLAN.md
+++ b/docs/conversion/PLAN.md
@@ -1,0 +1,26 @@
+# Conversion Plan: bear-notes-mcp to Claude Plugin
+
+## Overview
+
+Analysis of bear-notes-mcp's architecture and a clear strategy for converting it from a standalone MCP server into a Claude Plugin that works across Claude Code, Cowork, and Claude.ai — with a clear explanation of why "just a skill" won't work and "plugin" is the correct target.
+
+## Tasks
+
+- [ ] **Create plugin scaffold** -- Create the plugin directory structure with `.claude-plugin/plugin.json`, `skills/`, `commands/`, `agents/`, and `.mcp.json`
+- [ ] **Write SKILL.md** -- Write `skills/bear-notes/SKILL.md` with best practices for Claude when working with Bear Notes (search strategies, section targeting, tag conventions)
+- [ ] **Create slash commands** -- Create slash commands: `search.md`, `create.md`, `organize.md` in `commands/` directory
+- [ ] **Create sub-agent** -- Create `agents/note-curator.md` sub-agent for complex multi-step note workflows
+- [ ] **Write .mcp.json** -- Create `.mcp.json` that references `bear-notes-mcp` npm package with `userConfig` env var mapping
+- [ ] **Write plugin.json** -- Create plugin manifest with name, version, author, `userConfig` fields matching current MCPB `user_config`
+- [ ] **Test locally** -- Test the plugin locally with `claude --plugin-dir ./bear-notes-plugin`
+
+## Reference Documentation
+
+- [Claude Skills Overview](https://claude.com/docs/skills)
+- [Creating Custom Skills](https://claude.com/docs/skills/how-to)
+- [Agent Skills Specification](https://agentskills.io/specification)
+- [Connectors Overview](https://claude.com/docs/connectors/overview)
+- [Plugins Overview](https://claude.com/docs/plugins/overview)
+- [Claude Code Plugins Guide](https://code.claude.com/docs/en/plugins)
+- [Claude Code Plugins Reference](https://code.claude.com/docs/en/plugins-reference)
+- [Submitting a Plugin](https://claude.com/docs/plugins/submit)

--- a/docs/plans/2026-04-03-001-feat-bear-notes-claude-plugin-conversion-plan.md
+++ b/docs/plans/2026-04-03-001-feat-bear-notes-claude-plugin-conversion-plan.md
@@ -1,0 +1,366 @@
+---
+title: "feat: Convert Bear Notes MCP to Claude Plugin"
+type: feat
+status: completed
+date: 2026-04-03
+origin: docs/conversion/CONVERSION_OVERVIEW.md
+---
+
+## Enhancement Summary
+
+**Deepened on:** 2026-04-03
+**Sections enhanced:** 8
+**Research agents used:** agent-native-reviewer, architecture-strategist, security-sentinel, code-simplicity-reviewer, pattern-recognition-specialist, best-practices-researcher, performance-oracle
+
+### Key Improvements
+1. Simplified v1 scope — MVP is 5 core files; slash commands, sub-agent, and extras deferred to post-v1
+2. Fixed `allowed-tools` glob to match actual Claude plugin MCP tool naming convention
+3. Pinned MCP server version instead of `@latest` (consensus from architecture, security, performance reviews)
+4. Added SETUP.md skill for first-time configuration guidance
+5. Added operation-specific verify-after-write patterns for fire-and-forget writes
+
+### New Considerations Discovered
+- `allowed-tools: mcp__bear-notes-*` is the WRONG format — must be `mcp__plugin_bear-notes_bear-notes__*`
+- `userConfig` has no `type` or `default` field in the schema — document accepted values in `description`
+- `marketplace.json` should live in `.claude-plugin/`, not the repo root
+- `npx` cold start can be 2-15 seconds; document global install as the faster alternative
+- Sub-agent with 25 turns risks blowing the context window if tool results include full note bodies
+
+---
+
+# feat: Convert Bear Notes MCP to Claude Plugin
+
+## Overview
+
+Wrap the existing `bear-notes-mcp` MCP server (v2.9.0) in a Claude Plugin so it works in Claude Code and Cowork — not just Claude Desktop (MCPB) and standalone MCP clients. No changes to the MCP server code. The plugin adds a skill layer (best-practice instructions) and a `.mcp.json` that references the published npm package.
+
+**Key insight from research:** This cannot be "just a skill." Skills are markdown-only prompt instructions. They cannot access SQLite databases or execute x-callback-url commands. The MCP server must remain the connector layer; the plugin wraps it with skills and configuration (see origin: `docs/conversion/CONVERSION_OVERVIEW.md`).
+
+**Scope statement (from agent-native review):** This plugin provides parity with the **12 MCP tools**, not full Bear app UI parity. Actions like delete, trash recovery, pin to sidebar, and export are outside the MCP surface and therefore outside the plugin.
+
+## Problem Statement / Motivation
+
+The MCP server already works well as a connector. But users who want to use Bear Notes in Claude Code or Cowork have no way to install it as a first-class plugin with skills and configuration. The plugin format is the distribution unit for these platforms — it bundles the connector with higher-level workflow guidance.
+
+## Proposed Solution
+
+Create a **new directory** (`bear-notes-plugin/`) alongside the existing codebase. This is a lightweight wrapper — markdown files plus configuration — that references the published `bear-notes-mcp` npm package via `.mcp.json`.
+
+### v1 Target Directory Structure (Simplified)
+
+```
+bear-notes-plugin/
+├── .claude-plugin/
+│   └── plugin.json              # Plugin manifest with userConfig
+├── .mcp.json                    # MCP server → npx bear-notes-mcp@2
+├── skills/
+│   └── bear-notes/
+│       └── SKILL.md             # Best practices + tool reference
+├── skills/
+│   └── setup/
+│       └── SKILL.md             # First-time setup guidance
+└── README.md
+```
+
+### Research Insights (Code Simplicity Reviewer)
+
+**MVP is 5 files.** The minimum to ship "Bear Notes works in Claude Code/Cowork" is: `plugin.json` + `.mcp.json` + `skills/bear-notes/SKILL.md` + `skills/setup/SKILL.md` + `README.md`. Everything else is polish.
+
+**Deferred to post-v1:**
+- Slash commands (`commands/search.md`, `create.md`, `organize.md`) — the skill handles these workflows via auto-invocation
+- Sub-agent (`agents/note-curator.md`) — bulk workflows can be handled by skill instructions initially
+- `TOOL_REFERENCE.md` — fold into SKILL.md directly; MCP server already provides tool descriptions
+- `marketplace.json` — add when publishing to marketplace
+- `CHANGELOG.md` — add at second release
+
+## Technical Considerations
+
+### Plugin Manifest (`plugin.json`)
+
+Mirror the existing MCPB `user_config` fields as plugin `userConfig`:
+
+```json
+{
+  "name": "bear-notes",
+  "version": "1.0.0",
+  "description": "Search, read, create, and update Bear Notes from Claude Code and Cowork. macOS only.",
+  "author": { "name": "Serhii Vasylenko" },
+  "repository": "https://github.com/vasylenko/bear-notes-mcp",
+  "homepage": "https://github.com/vasylenko/bear-notes-mcp",
+  "license": "MIT",
+  "keywords": ["bear", "notes", "productivity", "markdown", "macos"],
+  "userConfig": {
+    "debug": {
+      "description": "Enable debug logging for troubleshooting (true or false, default: false)",
+      "sensitive": false
+    },
+    "enable_new_note_convention": {
+      "description": "Place tags after title instead of at bottom when creating notes (true or false, default: false)",
+      "sensitive": false
+    },
+    "enable_content_replacement": {
+      "description": "Allow replacing note content via bear-replace-text — DESTRUCTIVE, use with caution (true or false, default: false)",
+      "sensitive": false
+    }
+  }
+}
+```
+
+### Research Insights (Pattern Recognition + Best Practices)
+
+- `userConfig` has **no `type` or `default` field** in the schema — document accepted values and defaults in the `description` string itself
+- Values are **stringly-typed** (user types at enable time); validate in server or SessionStart hook
+- Non-sensitive values stored in `settings.json` under `pluginConfigs[].options`
+- Exported as `CLAUDE_PLUGIN_OPTION_*` env vars to subprocesses
+
+### Environment Contract
+
+Single source of truth for how configuration flows from plugin UI to server behavior:
+
+| `userConfig` key | `.mcp.json` env var | Server reads | Default | Effect |
+|---|---|---|---|---|
+| `debug` | `UI_DEBUG_TOGGLE` | `src/utils.ts:14-19` | `false` | Sets `DEBUG=bear-notes-mcp:*` |
+| `enable_new_note_convention` | `UI_ENABLE_NEW_NOTE_CONVENTION` | `src/config.ts:9` | `false` | Tags after title on create |
+| `enable_content_replacement` | `UI_ENABLE_CONTENT_REPLACEMENT` | `src/config.ts:10` | `false` | Enables `bear-replace-text` tool |
+
+### MCP Connector (`.mcp.json`)
+
+```json
+{
+  "mcpServers": {
+    "bear-notes": {
+      "command": "npx",
+      "args": ["-y", "bear-notes-mcp@2"],
+      "env": {
+        "UI_DEBUG_TOGGLE": "${user_config.debug}",
+        "UI_ENABLE_NEW_NOTE_CONVENTION": "${user_config.enable_new_note_convention}",
+        "UI_ENABLE_CONTENT_REPLACEMENT": "${user_config.enable_content_replacement}"
+      }
+    }
+  }
+}
+```
+
+### Research Insights (Architecture + Security + Performance)
+
+**Version pinning (consensus from 3 agents):** Use `bear-notes-mcp@2` (major pin) instead of `@latest`:
+- Prevents non-deterministic behavior across machines
+- Eliminates supply chain risk from surprise upgrades
+- Reduces cold start variability
+- Document upgrade path: bump version in `.mcp.json` when new major releases
+
+**Alternative for power users:** Document global install for faster startup:
+```bash
+npm i -g bear-notes-mcp
+# Then use command: "bear-notes-mcp" instead of npx
+```
+
+**npx cold start:** First run can take 2-15+ seconds (registry fetch + extract). Warm cache: ~200ms-2s. Document this expected behavior.
+
+**MCP server key:** The key `"bear-notes"` in `.mcp.json` becomes part of the tool prefix. Keep it stable — renaming would break `allowed-tools` references.
+
+### Skill Design (`SKILL.md`)
+
+The skill teaches Claude *how to use the tools well*, not what tools exist. The MCP server's tool descriptions handle that.
+
+**Frontmatter:**
+```yaml
+---
+name: bear-notes
+description: Best practices for searching, reading, creating, and updating Bear Notes via MCP tools. Use when the user mentions Bear, notes, or note-taking workflows on macOS.
+allowed-tools: mcp__plugin_bear-notes_bear-notes__*
+---
+```
+
+### Research Insights (Pattern Recognition — Critical Fix)
+
+The `allowed-tools` format `mcp__bear-notes-*` from the original plan is **WRONG**. The actual Claude plugin MCP tool naming convention is:
+
+```
+mcp__plugin_<plugin-name>_<server-key>__<tool-name>
+```
+
+For plugin `bear-notes` with MCP server key `bear-notes`:
+- `mcp__plugin_bear-notes_bear-notes__bear-open-note`
+- `mcp__plugin_bear-notes_bear-notes__bear-search-notes`
+- etc.
+
+**Use:** `allowed-tools: mcp__plugin_bear-notes_bear-notes__*`
+
+**Verify after first test:** Run `/mcp` in Claude Code with the plugin loaded to confirm actual tool names, then update the glob or switch to an explicit list.
+
+### Skill Content Sections
+
+1. **Platform requirement**: macOS only. Bear must be installed and have been opened at least once.
+2. **Search strategy**: Use `bear-search-notes` first to get IDs, then `bear-open-note` to read content. Or use title-based lookup for exact matches.
+3. **Section targeting**: Bear notes use markdown headings. `bear-add-text` and `bear-replace-text` target sections by header name — only direct content under that header, not nested sub-sections.
+4. **Tag conventions**: Tags are slash-delimited hierarchies (e.g., `work/meetings`). Use `bear-list-tags` to discover existing hierarchy before creating new tags.
+5. **Safety**: Content replacement is opt-in and destructive. Always confirm with the user before replacing note content. There is no undo via the MCP server. No delete-note tool exists by design.
+6. **Verify-after-write pattern** (from agent-native review): Writes are fire-and-forget via Bear's x-callback-url — the MCP server cannot confirm Bear processed them. Verification must be **operation-specific** because archived/trashed notes are excluded from all read queries (`ZARCHIVED = 0` in `src/notes.ts:103,179,278`):
+   - **create / add-text / replace-text / add-tag / add-file**: Read the note back via `bear-open-note` to confirm the change applied.
+   - **archive**: Verify the note **disappears** from active results — call `bear-open-note` and confirm it returns "not found." A successful archive means the note is no longer readable through the MCP.
+   - **rename-tag / delete-tag**: Verify via `bear-list-tags` — confirm the old tag name is gone and the new name appears (rename) or the tag is absent (delete). These are global operations with no per-note pre-flight check.
+7. **Bulk operations**: When working with multiple notes, process sequentially and confirm with the user every 10-20 notes. Summarize planned changes before executing.
+8. **Quick tool reference**: Inline table of all 12 tools with one-line descriptions (replaces separate TOOL_REFERENCE.md).
+9. **Troubleshooting**: Common issues — Bear not installed, Node version < 24.13.0, database permissions, enabling debug logging.
+
+### Research Insights (Agent-Native + Security)
+
+**Operation-specific verification is critical.** The x-callback-url is fire-and-forget: `open -g "bear://..."` returns exit code 0 if macOS accepted the URL, not if Bear processed it. The skill must instruct Claude to verify mutations — but the verification strategy differs by operation because archived notes are filtered from all read paths (`ZARCHIVED = 0`). A naive "read the note back" after archive would look like a failure when it's actually the expected success state.
+
+**Debug logging caveat (security):** When `UI_DEBUG_TOGGLE=true`, the server sets `DEBUG=bear-notes-mcp:*` which enables all debug loggers. This includes `buildBearUrl()` in `src/bear-urls.ts:80` which logs the full constructed Bear URL — including note text, tags, and base64 attachment payloads for write operations. This is a **known data exposure risk** in the current server. The plugin cannot fix this without server changes, so the SKILL.md must warn users: "Debug mode logs full note content and file attachments to stderr. Do not enable in shared or logged environments if your notes contain sensitive data." A future server improvement could redact body content from debug URLs, but that is out of scope for this plugin (no server changes).
+
+**Content replacement gates:** The `enable_content_replacement` userConfig toggle is the primary gate. The skill should add a secondary soft gate: always preview the replacement (show diff-style before/after) and get user confirmation.
+
+### SETUP.md Skill
+
+A small skill to guide first-time plugin setup:
+
+```yaml
+---
+name: setup
+description: Guide user through Bear Notes plugin setup and verification. Use when the plugin is first installed or when troubleshooting connection issues.
+disable-model-invocation: true
+---
+```
+
+Content: Verify Bear is installed, check Node version, test MCP connection by calling `bear-list-tags`, explain userConfig options.
+
+### Distribution
+
+| Channel | Format | Status |
+|---------|--------|--------|
+| Claude Desktop | `.mcpb` bundle | Keep as-is (existing) |
+| Claude Code | Plugin via `--plugin-dir` or marketplace | New (this plan) |
+| Claude Cowork | Plugin (same as Code) | New (this plan) |
+| npm | Standalone MCP server | Keep as-is (existing) |
+
+### Research Insights (Best Practices + Submission)
+
+**For marketplace submission (post-v1):**
+- `marketplace.json` goes in `.claude-plugin/` with `$schema` URL
+- Anthropic prefers plugins that bundle skills + MCP into coherent job-oriented packages
+- Include a `SETUP.md` skill — Anthropic's submission docs specifically call this out
+- Use connectors from the Connectors Directory or well-known publishers for higher verification odds
+- Submit via [claude.ai/settings/plugins/submit](https://claude.ai/settings/plugins/submit)
+
+**marketplace.json structure** (when ready):
+```json
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "bear-notes-plugin",
+  "owner": { "name": "Serhii Vasylenko", "url": "https://github.com/vasylenko" },
+  "plugins": [{
+    "name": "bear-notes",
+    "version": "1.0.0",
+    "description": "Search, read, create, and update Bear Notes from Claude Code and Cowork.",
+    "source": "./"
+  }]
+}
+```
+
+## System-Wide Impact
+
+- **No changes to the MCP server**: The existing `bear-notes-mcp` npm package and MCPB are untouched.
+- **Parallel distribution**: MCPB (Desktop) and plugin (Code/Cowork) coexist. Users choose based on their Claude client.
+- **Concurrent access**: Both MCPB and plugin hit the same Bear SQLite database. SQLite is read-only in the server; writes serialize through Bear's URL scheme internally. No locking needed.
+- **Platform constraint**: macOS only. Document prominently in plugin description, SKILL.md, and README.
+
+### Research Insights (Security)
+
+**Supply chain mitigations:**
+- Pin to major version (`@2`) in `.mcp.json`
+- Document npm package name explicitly to prevent typosquatting
+- Consider adding SHA256 checksum of published tarball in README for high-assurance users
+- Run `npm audit` in CI for the MCP server package
+
+**x-callback-url safety:**
+- Bear URL builder must use strict allowlist, percent-encoding, and reject control characters
+- Never pass raw model output directly into `open` command — parse into structured fields first
+- Already handled in `src/bear-urls.ts` (verify in code review)
+
+## Acceptance Criteria
+
+### v1 (Ship)
+
+**Structural:**
+- [ ] `plugin.json` manifest with `userConfig` matching MCPB's three settings
+- [ ] `.mcp.json` referencing `bear-notes-mcp@2` with env substitution
+- [ ] `skills/bear-notes/SKILL.md` with search strategy, section targeting, tag conventions, operation-specific verify-after-write, safety, and troubleshooting
+- [ ] `skills/setup/SKILL.md` for first-time setup guidance
+- [ ] `README.md` with install instructions for Claude Code and Cowork
+
+**Functional — plugin loading:**
+- [ ] Plugin loads via `claude --plugin-dir ./bear-notes-plugin`
+- [ ] All 12 MCP tools accessible after plugin installation
+- [ ] `allowed-tools` glob verified against actual tool names via `/mcp`
+
+**Functional — userConfig end-to-end (validates the env contract):**
+- [ ] With `enable_content_replacement` set to `true`: `bear-replace-text` executes successfully (does not return "Content replacement is not enabled")
+- [ ] With `enable_content_replacement` unset or `false`: `bear-replace-text` returns the "not enabled" gate message (confirms the gate at `src/main.ts:434` fires)
+- [ ] With `enable_new_note_convention` set to `true`: `bear-create-note` places tags after the title (not at the bottom)
+- [ ] With `debug` set to `true`: MCP server stderr shows `bear-notes-mcp:*` debug output
+
+### Post-v1 (Defer)
+- [ ] `commands/search.md`, `create.md`, `organize.md` slash commands
+- [ ] `agents/note-curator.md` sub-agent with bulk operation guardrails
+- [ ] `.claude-plugin/marketplace.json` for marketplace distribution
+- [ ] Submit to Anthropic plugin directory
+- [ ] `CHANGELOG.md`
+
+## Success Metrics
+
+- Plugin installs and connects to Bear without manual `.mcp.json` editing
+- Skill activates when users mention Bear Notes in conversation
+- 12 MCP tools work identically to standalone MCP server usage
+- First-time setup guidance helps users configure all three options
+
+## Dependencies & Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `npx` cold start 2-15s on first use | Medium | Document; recommend global install for power users |
+| `bear-notes-mcp@2` major version boundary | Medium | Pin to `@2`; document upgrade when v3 ships |
+| Node.js >=24.13.0 not available in Cowork | Medium | Document requirement; setup skill checks version |
+| Bear not installed on user's Mac | Low | Setup skill verifies; MCP errors surface naturally |
+| `userConfig` boolean as string (`"true"` vs `true`) | Low | Server already handles string env vars |
+| `allowed-tools` glob wrong after MCP naming change | Low | Verify via `/mcp` on first test; document in README |
+
+## MVP Implementation Order
+
+Files to create, in sequence:
+
+1. `bear-notes-plugin/.claude-plugin/plugin.json`
+2. `bear-notes-plugin/.mcp.json`
+3. `bear-notes-plugin/skills/bear-notes/SKILL.md`
+4. `bear-notes-plugin/skills/setup/SKILL.md`
+5. `bear-notes-plugin/README.md`
+
+**Total: 5 files. ~300 lines of markdown + ~30 lines of JSON.**
+
+## Sources & References
+
+### Origin
+
+- **Origin document:** [docs/conversion/CONVERSION_OVERVIEW.md](docs/conversion/CONVERSION_OVERVIEW.md) — Key decisions: plugin (not skill) is the correct target; MCP server stays untouched; `.mcp.json` references npm package
+
+### Internal References
+
+- Architecture: [.claude/contexts/SPECIFICATION.md](.claude/contexts/SPECIFICATION.md) — hybrid read/write model, safety gates
+- MCPB manifest: [manifest.json](manifest.json) — `user_config` fields (lines 37-58)
+- MCP tools: [src/main.ts](src/main.ts) — 12 tool registrations with Zod schemas
+- Config: [src/config.ts](src/config.ts) — env var to feature flag mapping (lines 6-10)
+
+### External References
+
+- [Claude Plugin Docs](https://code.claude.com/docs/en/plugins) — Plugin creation guide
+- [Plugin Reference](https://code.claude.com/docs/en/plugins-reference) — Manifest schema, userConfig, environment variables
+- [Agent Skills Specification](https://agentskills.io/specification) — SKILL.md format
+- [Plugin Submission](https://claude.com/docs/plugins/submit) — Marketplace submission process
+- [Plugin Marketplaces](https://code.claude.com/docs/en/plugin-marketplaces) — marketplace.json schema and distribution
+
+### Related Work
+
+- Existing plugin reference: [dailyzen-skill](https://github.com/kropdx/dailyzen-skill) — minimal plugin structure
+- Compound-engineering plugin — complex plugin with 42 skills, 29 agents, inline + file MCP configs
+- Existing conversion research: [docs/conversion/PLAN.md](docs/conversion/PLAN.md) — initial task list


### PR DESCRIPTION
## Summary

- Adds a **Claude Code & Cowork plugin** as a third distribution channel alongside the existing Claude Desktop extension and npm package
- Updates README with plugin installation section and plugin settings instructions for all three configuration options
- Includes conversion research docs (`docs/conversion/`) with architecture analysis of why a plugin (not just a skill) is the correct approach
- Includes a detailed implementation plan (`docs/plans/`) for the plugin, reviewed by 7 specialized agents

## What's in the plugin

The plugin is a lightweight wrapper — markdown files plus configuration — that references the published `bear-notes-mcp` npm package via `.mcp.json`. No MCP server code changes. It adds:

- **Bear Notes skill** — best practices for search strategy, section targeting, tag conventions, operation-specific verify-after-write patterns, and safety guidance
- **Setup skill** — `/bear-notes:setup` for first-time environment verification
- **Plugin settings** — debug, new note convention, and content replacement managed through Claude's plugin UI

The plugin source lives in a separate repo: the docs here explain the architecture and link to it.

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify existing installation paths (Claude Desktop, standalone MCP) are unchanged
- [ ] Test plugin locally with `claude --plugin-dir ./bear-notes-plugin`
- [ ] Confirm all 12 MCP tools load through the plugin

Made with [Cursor](https://cursor.com)