### PR TITLE
feat: add bear-grab-url tool for saving web pages as notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.10.0] - 2026-04-13
+## [Unreleased]
 
 ### Added
 - **`bear-grab-url`** tool — save a web page as a Bear note. Bear fetches the page and converts it to markdown. Supports optional comma-separated tags. The note is created in the background without bringing Bear to the foreground.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.0] - 2026-04-13
+
+### Added
+- **`bear-grab-url`** tool — save a web page as a Bear note. Bear fetches the page and converts it to markdown. Supports optional comma-separated tags. The note is created in the background without bringing Bear to the foreground.
+
+### Fixed
+- **Database reads no longer fail when Bear is writing** — the SQLite connection now sets a 3-second `busy_timeout`, so read queries wait briefly instead of failing instantly with "database is locked" when Bear happens to be mid-write.
+
 ## [2.9.0] - 2026-04-01
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,17 +34,23 @@ You are world-class NodeJS developer, senior engineer with a vast experience in 
 
 # Project Structure
 ```
-├── src/                   # Project source code
-│   ├── main.ts            # MCP server entry point
+├── src/                   # MCP server source code
+│   ├── main.ts            # Server entry point and tool registration
 │   ├── bear-urls.ts       # Bear app URL scheme handlers
 │   ├── database.ts        # SQLite database connection
 │   ├── notes.ts           # Note operations (search, content)
 │   ├── tags.ts            # Tag operations (list, hierarchy)
+│   ├── note-conventions.ts # Tag placement conventions for new notes
 │   ├── config.ts          # Configuration management
 │   ├── types.ts           # Type definitions
 │   └── utils.ts           # Shared utilities
+├── tests/system/          # System tests (require Bear app running)
+│   ├── inspector.ts       # Test helpers: callTool, pollUntil, cleanup
+│   └── *.test.ts          # Per-tool system test suites
+├── scripts/               # Build and doc automation scripts
 ├── dist/                  # Compiled JavaScript (build output)
 ├── assets/                # Static assets (icons, etc.)
+├── website/               # Promotional landing page (Astro + Tailwind)
 ├── manifest.json          # MCPB manifest
 ├── Taskfile.yml           # Task automation (build/test/pack)
 └── package.json           # Node.js dependencies and scripts
@@ -57,6 +63,10 @@ You are world-class NodeJS developer, senior engineer with a vast experience in 
 2 - Bear database schema brief - .claude/contexts/BEAR_DATABASE_SCHEMA.md - use this when working with tasks related to database access as a starting point
 
 # Core Workflows
+
+## Website
+
+Promotional single-page landing at `bear-notes-mcp.vercel.app` (Vercel free domain, no custom domain). Built with Astro + Tailwind CSS, lives in `website/`. When adding or removing tools, update the tool count in `website/src/components/FeatureGrid.astro` alongside README.md and docs/NPM.md.
 
 ## Release Process
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Example prompts:
 
 ## ✨ Key Features
 
-- **12 MCP tools** for searching, reading, creating, updating, tagging, and archiving notes
+- **13 MCP tools** for searching, reading, creating, updating, tagging, and archiving notes
 - **OCR search** — finds text inside attached images and PDFs
 - **Date-based search** with relative dates ("yesterday", "last week", "start of last month")
 - **Tag management** — list tags as a tree, find untagged notes, add tags to notes

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Add to your MCP configuration file:
 - **`bear-archive-note`** - Archive a Bear note to remove it from active lists without deleting it
 - **`bear-rename-tag`** - Rename a tag across all notes in your Bear library
 - **`bear-delete-tag`** - Delete a tag from all notes in your Bear library without affecting the notes
+- **`bear-grab-url`** - Save a web page as a Bear note. Bear fetches the page and converts it to markdown.
 <!-- TOOLS:END -->
 
 ## ⚙️ Configuration

--- a/docs/NPM.md
+++ b/docs/NPM.md
@@ -6,7 +6,7 @@ Search, read, create, and update your Bear Notes from any AI assistant.
 
 ## Key Features
 
-- **12 MCP tools** for full Bear Notes integration
+- **13 MCP tools** for full Bear Notes integration
 - **OCR search** across images and PDFs attached to notes
 - **Date-based search** with relative dates ("yesterday", "last week", etc.)
 - **Configurable new note convention** for tag placement (opt-in)

--- a/docs/NPM.md
+++ b/docs/NPM.md
@@ -28,6 +28,7 @@ Search, read, create, and update your Bear Notes from any AI assistant.
 - **`bear-archive-note`** - Archive a Bear note to remove it from active lists without deleting it
 - **`bear-rename-tag`** - Rename a tag across all notes in your Bear library
 - **`bear-delete-tag`** - Delete a tag from all notes in your Bear library without affecting the notes
+- **`bear-grab-url`** - Save a web page as a Bear note. Bear fetches the page and converts it to markdown.
 <!-- TOOLS:END -->
 
 **Requirements**: Node.js 24.13.0+

--- a/manifest.json
+++ b/manifest.json
@@ -105,6 +105,10 @@
     {
       "name": "bear-delete-tag",
       "description": "Delete a tag from all notes in your Bear library without affecting the notes"
+    },
+    {
+      "name": "bear-grab-url",
+      "description": "Save a web page as a Bear note. Bear fetches the page and converts it to markdown."
     }
   ],
   "keywords": [

--- a/src/bear-urls.test.ts
+++ b/src/bear-urls.test.ts
@@ -15,4 +15,25 @@ describe('buildBearUrl', () => {
 
     expect(url).toContain('1%2B1%3D2');
   });
+
+  it('encodes url param for grab-url action', () => {
+    const url = buildBearUrl('grab-url', { url: 'https://example.com/page?q=hello world' });
+
+    expect(url).toContain('grab-url?');
+    expect(url).toContain('url=https%3A%2F%2Fexample.com%2Fpage%3Fq%3Dhello%20world');
+  });
+
+  it('includes pin and wait params when provided', () => {
+    const url = buildBearUrl('grab-url', { url: 'https://example.com', pin: 'no', wait: 'yes' });
+
+    expect(url).toContain('pin=no');
+    expect(url).toContain('wait=yes');
+  });
+
+  it('omits pin and wait params when undefined', () => {
+    const url = buildBearUrl('grab-url', { url: 'https://example.com' });
+
+    expect(url).not.toContain('pin=');
+    expect(url).not.toContain('wait=');
+  });
 });

--- a/src/bear-urls.ts
+++ b/src/bear-urls.ts
@@ -18,6 +18,9 @@ export interface BearUrlParams {
   filename?: string | undefined;
   name?: string | undefined;
   new_name?: string | undefined;
+  url?: string | undefined;
+  pin?: 'yes' | 'no' | undefined;
+  wait?: 'yes' | 'no' | undefined;
   open_note?: 'yes' | 'no' | undefined;
   new_window?: 'yes' | 'no' | undefined;
   show_window?: 'yes' | 'no' | undefined;
@@ -52,6 +55,7 @@ export function buildBearUrl(action: string, params: BearUrlParams = {}): string
     'filename',
     'name',
     'new_name',
+    'url',
   ] as const;
   for (const key of stringParams) {
     const value = params[key];
@@ -66,6 +70,14 @@ export function buildBearUrl(action: string, params: BearUrlParams = {}): string
 
   if (params.new_line !== undefined) {
     urlParams.set('new_line', params.new_line);
+  }
+
+  if (params.pin !== undefined) {
+    urlParams.set('pin', params.pin);
+  }
+
+  if (params.wait !== undefined) {
+    urlParams.set('wait', params.wait);
   }
 
   // UX params with defaults

--- a/src/database.ts
+++ b/src/database.ts
@@ -51,6 +51,13 @@ export function openBearDatabase(): DatabaseSync {
   try {
     const db = new DatabaseSync(databasePath, { readOnly: true });
 
+    // Bear uses journal_mode=delete (not WAL), so readers and writers block each other.
+    // Without busy_timeout, our reads fail instantly if Bear is mid-write.
+    // DatabaseSync has no constructor option for this (nodejs/node#57597),
+    // so we set it via PRAGMA after opening. Blocks the thread while waiting,
+    // which is fine for sequential stdio MCP transport.
+    db.exec('PRAGMA busy_timeout = 3000');
+
     logger.debug('Bear database opened successfully');
     return db;
   } catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -926,6 +926,62 @@ The tag has been removed from all notes. The notes themselves are not affected.`
   }
 );
 
+server.registerTool(
+  'bear-grab-url',
+  {
+    title: 'Grab URL as Note',
+    description:
+      'Save a web page as a Bear note. Bear fetches the page and converts it to markdown. The note is created in the background without bringing Bear to the foreground.',
+    inputSchema: {
+      url: z
+        .string()
+        .trim()
+        .url('A valid URL is required (e.g., https://example.com)')
+        .refine((u) => /^https?:\/\//i.test(u), 'Only http and https URLs are supported')
+        .describe('URL of the web page to save as a Bear note'),
+      tags: z
+        .string()
+        .trim()
+        .optional()
+        .describe('Tags separated by commas, e.g., "research,article,tech"'),
+    },
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+  },
+  async ({ url, tags }): Promise<CallToolResult> => {
+    logger.info(`bear-grab-url called with url: "${url}", tags: ${tags || 'none'}`);
+
+    try {
+      const bearUrl = buildBearUrl('grab-url', {
+        url,
+        tags,
+        pin: 'no',
+        wait: 'yes',
+        open_note: 'no',
+        show_window: 'no',
+        new_window: 'no',
+      });
+
+      await executeBearXCallbackApi(bearUrl);
+
+      const tagLine = tags ? `\nTags: ${tags}` : '';
+
+      return createToolResponse(`Web page grab request sent to Bear!
+
+URL: ${url}${tagLine}
+
+Bear is fetching the page and converting it to a note. This may take a moment for large pages.`);
+    } catch (error) {
+      logger.error('bear-grab-url failed:', error);
+      throw error;
+    }
+  }
+);
+
 async function main(): Promise<void> {
   logger.info(`Bear Notes MCP Server initializing... Version: ${APP_VERSION}`);
   logger.debug(`Debug logs enabled: ${logger.debug.enabled}`);

--- a/tests/system/grab-url.test.ts
+++ b/tests/system/grab-url.test.ts
@@ -1,0 +1,60 @@
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { callTool, pollUntil, trashNote, tryExtractNoteId } from './inspector.js';
+
+const RUN_ID = Date.now();
+const TAG = `stest-grab-url-${RUN_ID}`;
+
+afterAll(() => {
+  // Tag-based cleanup: grab-url notes have titles from the web page, not from us,
+  // so prefix-based cleanupTestNotes() cannot find them
+  try {
+    const searchResult = callTool({
+      toolName: 'bear-search-notes',
+      args: { tag: TAG },
+    }).content[0].text;
+    const idMatches = searchResult.matchAll(/ID:\s+([A-Fa-f0-9-]+)/g);
+    for (const match of idMatches) {
+      trashNote(match[1]);
+    }
+  } catch {
+    // Best-effort
+  }
+});
+
+describe('bear-grab-url via MCP Inspector CLI', () => {
+  it('grabs a URL and creates a note with tags', async () => {
+    let noteId: string | undefined;
+
+    try {
+      const result = callTool({
+        toolName: 'bear-grab-url',
+        args: { url: 'https://example.com', tags: TAG },
+      }).content[0].text;
+
+      expect(result).toContain('Web page grab request sent to Bear!');
+      expect(result).toContain('https://example.com');
+      expect(result).toContain(TAG);
+
+      // Poll until Bear finishes fetching the page and the note appears
+      const searchResponse = await pollUntil(
+        () => callTool({ toolName: 'bear-search-notes', args: { tag: TAG } }),
+        (r) => tryExtractNoteId(r.content[0].text) !== null,
+        { timeoutMs: 10_000, label: `note with tag "${TAG}" after grab-url` }
+      );
+
+      noteId = tryExtractNoteId(searchResponse.content[0].text) ?? undefined;
+      expect(noteId, `Expected a note with tag "${TAG}" after grab-url`).toBeDefined();
+
+      // Verify the note has content from the page
+      const noteContent = callTool({
+        toolName: 'bear-open-note',
+        args: { id: noteId! },
+      }).content[0].text;
+
+      expect(noteContent).toContain('Example Domain');
+    } finally {
+      if (noteId) trashNote(noteId);
+    }
+  });
+});

--- a/tests/system/inspector.ts
+++ b/tests/system/inspector.ts
@@ -140,6 +140,32 @@ export function uniqueTitle(prefix: string, label: string, runId: number): strin
   return `${prefix} ${label} ${runId}`;
 }
 
+interface PollOptions {
+  timeoutMs?: number;
+  intervalMs?: number;
+  label?: string;
+}
+
+/**
+ * Polls an action until a predicate is satisfied or the timeout expires.
+ * Replaces ad-hoc while loops across system tests.
+ */
+export async function pollUntil<T>(
+  action: () => T,
+  predicate: (result: T) => boolean,
+  { timeoutMs = 5_000, intervalMs = 1_000, label = 'condition' }: PollOptions = {}
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const result = action();
+    if (predicate(result)) return result;
+    await sleep(intervalMs);
+  }
+
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for ${label}`);
+}
+
 /**
  * Polls bear-open-note until the attached-files content block contains the expected marker.
  * Avoids flaky fixed sleeps by polling for actual content availability (e.g. OCR text or filename).
@@ -149,19 +175,10 @@ export async function waitForFileContent(
   marker: string,
   timeoutMs = 15_000
 ): Promise<ToolResponse> {
-  const interval = 1_000;
-  const deadline = Date.now() + timeoutMs;
-
-  while (Date.now() < deadline) {
-    const response = callTool({ toolName: 'bear-open-note', args: { id: noteId } });
-    if (response.content.length > 1 && response.content[1].text.includes(marker)) {
-      return response;
-    }
-    await sleep(interval);
-  }
-
-  throw new Error(
-    `Timed out after ${timeoutMs}ms waiting for file content containing "${marker}" in note ${noteId}`
+  return pollUntil(
+    () => callTool({ toolName: 'bear-open-note', args: { id: noteId } }),
+    (r) => r.content.length > 1 && r.content[1].text.includes(marker),
+    { timeoutMs, label: `file content "${marker}" in note ${noteId}` }
   );
 }
 

--- a/website/src/components/FeatureGrid.astro
+++ b/website/src/components/FeatureGrid.astro
@@ -18,7 +18,7 @@ const categories = [
 <section class="py-14 sm:py-20">
   <div class="text-center max-w-2xl mx-auto mb-12">
     <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight">
-      12 tools, three jobs
+      13 tools, three jobs
     </h2>
     <p class="mt-4 text-text-secondary leading-relaxed">
       Each tool does one thing well.


### PR DESCRIPTION
## Summary
- Adds `bear-grab-url` MCP tool that saves a web page as a Bear note using Bear's native `grab-url` x-callback-url action
- Bear fetches the page content and converts it to markdown automatically; the note title comes from the page itself
- Accepts a required `url` (validated as a proper URL via Zod) and optional comma-separated `tags`
- Runs in the background with Bear UX suppressed (no window focus, no new window, no note opened)
- Adds `PRAGMA busy_timeout = 3000` to the SQLite database connection so reads retry for up to 3 seconds when Bear is mid-write, instead of failing with "database is locked" (Bear uses `journal_mode=delete`, not WAL)

## Why
Saving web pages as notes is a core Bear workflow — clipping articles, reference docs, and research material. This tool brings that capability to MCP clients, letting users save pages without switching to Bear.

The `busy_timeout` fix addresses a broader reliability issue: any tool that reads the database can hit a lock conflict when Bear happens to be writing (e.g., right after a grab-url creates a note). This was surfaced by the grab-url system test but benefits all read operations.

--
Implements [SVA-10](https://linear.app/svasylenko/issue/SVA-10)