### PR TITLE
Add Buy Me a Coffee support button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: vasylenko
+buy_me_a_coffee: vasylenko

--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,1 +1,0 @@
-github: vasylenko

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Supply Chain](https://github.com/vasylenko/bear-notes-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/vasylenko/bear-notes-mcp/actions/workflows/ci.yml)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/vasylenko/bear-notes-mcp)
+[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-d42a35?logo=buy-me-a-coffee&logoColor=white)](https://buymeacoffee.com/vasylenko)
 
 # Bear Notes MCP Server
 

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -4,32 +4,18 @@ import { site } from '../data/site';
 
 <footer class="py-16">
   <div class="flex flex-col items-center gap-8">
-    <div class="flex flex-wrap justify-center gap-3">
-      <!-- Star CTA — open source social proof -->
-      <a
-        href={site.links.github}
-        class="inline-flex items-center gap-2 rounded-full border border-border bg-white px-5 py-2 text-sm font-medium text-text-secondary shadow-sm hover:border-border-hover hover:text-text-primary transition-all"
-        target="_blank"
-        rel="noopener"
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z" />
-        </svg>
-        Star on GitHub
-      </a>
-      <!-- Support CTA -->
-      <a
-        href={site.links.support}
-        class="inline-flex items-center gap-2 rounded-full border border-border bg-white px-5 py-2 text-sm font-medium text-text-secondary shadow-sm hover:border-border-hover hover:text-text-primary transition-all"
-        target="_blank"
-        rel="noopener"
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-accent" fill="currentColor" viewBox="0 0 24 24" stroke="none" aria-hidden="true">
-          <path d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z" />
-        </svg>
-        Support this project
-      </a>
-    </div>
+    <!-- Star CTA — open source social proof -->
+    <a
+      href={site.links.github}
+      class="inline-flex items-center gap-2 rounded-full border border-border bg-white px-5 py-2 text-sm font-medium text-text-secondary shadow-sm hover:border-border-hover hover:text-text-primary transition-all"
+      target="_blank"
+      rel="noopener"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z" />
+      </svg>
+      Star on GitHub
+    </a>
 
     <nav class="flex flex-wrap justify-center gap-8 text-sm text-text-muted" aria-label="Footer">
       <a href={site.links.github} class="hover:text-text-primary transition-colors" target="_blank" rel="noopener">GitHub</a>

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -4,18 +4,32 @@ import { site } from '../data/site';
 
 <footer class="py-16">
   <div class="flex flex-col items-center gap-8">
-    <!-- Star CTA — open source social proof -->
-    <a
-      href={site.links.github}
-      class="inline-flex items-center gap-2 rounded-full border border-border bg-white px-5 py-2 text-sm font-medium text-text-secondary shadow-sm hover:border-border-hover hover:text-text-primary transition-all"
-      target="_blank"
-      rel="noopener"
-    >
-      <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z" />
-      </svg>
-      Star on GitHub
-    </a>
+    <div class="flex flex-wrap justify-center gap-3">
+      <!-- Star CTA — open source social proof -->
+      <a
+        href={site.links.github}
+        class="inline-flex items-center gap-2 rounded-full border border-border bg-white px-5 py-2 text-sm font-medium text-text-secondary shadow-sm hover:border-border-hover hover:text-text-primary transition-all"
+        target="_blank"
+        rel="noopener"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z" />
+        </svg>
+        Star on GitHub
+      </a>
+      <!-- Support CTA -->
+      <a
+        href={site.links.support}
+        class="inline-flex items-center gap-2 rounded-full border border-border bg-white px-5 py-2 text-sm font-medium text-text-secondary shadow-sm hover:border-border-hover hover:text-text-primary transition-all"
+        target="_blank"
+        rel="noopener"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-accent" fill="currentColor" viewBox="0 0 24 24" stroke="none" aria-hidden="true">
+          <path d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z" />
+        </svg>
+        Support this project
+      </a>
+    </div>
 
     <nav class="flex flex-wrap justify-center gap-8 text-sm text-text-muted" aria-label="Footer">
       <a href={site.links.github} class="hover:text-text-primary transition-colors" target="_blank" rel="noopener">GitHub</a>

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -7,9 +7,9 @@ import { site } from '../data/site';
     <!-- Star CTA — open source social proof -->
     <a
       href={site.links.github}
-      class="inline-flex items-center gap-2 rounded-full border border-border bg-white px-5 py-2 text-sm font-medium text-text-secondary shadow-sm hover:border-border-hover hover:text-text-primary transition-all"
+      class="cta-pill"
       target="_blank"
-      rel="noopener"
+      rel="noopener noreferrer"
     >
       <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z" />
@@ -18,15 +18,15 @@ import { site } from '../data/site';
     </a>
 
     <nav class="flex flex-wrap justify-center gap-8 text-sm text-text-muted" aria-label="Footer">
-      <a href={site.links.github} class="hover:text-text-primary transition-colors" target="_blank" rel="noopener">GitHub</a>
-      <a href={site.links.npm} class="hover:text-text-primary transition-colors" target="_blank" rel="noopener">npm</a>
+      <a href={site.links.github} class="hover:text-text-primary transition-colors" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href={site.links.npm} class="hover:text-text-primary transition-colors" target="_blank" rel="noopener noreferrer">npm</a>
       <a href="/updates" class="hover:text-text-primary transition-colors">How to Update</a>
-      <a href={site.links.bearApp} class="hover:text-text-primary transition-colors" target="_blank" rel="noopener">Bear App</a>
-      <a href={site.links.mcpSpec} class="hover:text-text-primary transition-colors" target="_blank" rel="noopener">MCP Protocol</a>
+      <a href={site.links.bearApp} class="hover:text-text-primary transition-colors" target="_blank" rel="noopener noreferrer">Bear App</a>
+      <a href={site.links.mcpSpec} class="hover:text-text-primary transition-colors" target="_blank" rel="noopener noreferrer">MCP Protocol</a>
     </nav>
 
     <p class="text-sm text-text-muted">
-      Built by <a href={site.author.url} class="text-text-primary font-medium hover:text-accent transition-colors" target="_blank" rel="noopener">{site.author.name}</a>
+      Built by <a href={site.author.url} class="text-text-primary font-medium hover:text-accent transition-colors" target="_blank" rel="noopener noreferrer">{site.author.name}</a>
       <span class="mx-1.5 opacity-30">·</span>
       MIT License
     </p>

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -11,13 +11,13 @@ import InstallTabs from './InstallTabs.astro';
     <div>
       <!-- Trust signals — populated client-side via shields.io JSON API -->
       <div id="trust-signals" class="hidden flex items-center justify-center xl:justify-start gap-3 mb-8 animate-on-scroll">
-        <a href={`${site.links.github}/stargazers`} class="trust-pill" target="_blank" rel="noopener">
+        <a href={`${site.links.github}/stargazers`} class="trust-pill" target="_blank" rel="noopener noreferrer">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 text-accent" fill="currentColor" viewBox="0 0 24 24" stroke="none" aria-hidden="true">
             <path d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z" />
           </svg>
           <span id="stars-count" class="font-semibold text-text-primary"></span>
         </a>
-        <a href={site.links.npm} class="trust-pill" target="_blank" rel="noopener">
+        <a href={site.links.npm} class="trust-pill" target="_blank" rel="noopener noreferrer">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 text-text-muted" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
           </svg>
@@ -34,7 +34,7 @@ import InstallTabs from './InstallTabs.astro';
 
       <p class="mt-8 text-lg sm:text-xl text-text-secondary max-w-lg xl:max-w-2xl mx-auto xl:mx-0 leading-relaxed animate-on-scroll" style="animation-delay: 200ms;">
         An MCP server that gives your AI assistant full access to your
-        <a href={site.links.bearApp} class="text-text-primary font-semibold hover:text-accent transition-colors" target="_blank" rel="noopener">Bear</a>
+        <a href={site.links.bearApp} class="text-text-primary font-semibold hover:text-accent transition-colors" target="_blank" rel="noopener noreferrer">Bear</a>
         notes. Search with OCR, create, edit, and organize.
       </p>
 

--- a/website/src/components/InstallTabs.astro
+++ b/website/src/components/InstallTabs.astro
@@ -57,7 +57,7 @@ const cliTabs = [
       <ol class="space-y-5 text-text-secondary">
         <li class="flex gap-4">
           <span class="flex-shrink-0 text-xl font-light text-accent/30" aria-hidden="true">1</span>
-          <span class="pt-0.5">Download the <a href={site.install.claudeDesktop.downloadUrl} class="text-accent underline decoration-accent/30 underline-offset-4 hover:decoration-accent transition-colors" target="_blank" rel="noopener">.mcpb extension</a> from GitHub Releases</span>
+          <span class="pt-0.5">Download the <a href={site.install.claudeDesktop.downloadUrl} class="text-accent underline decoration-accent/30 underline-offset-4 hover:decoration-accent transition-colors" target="_blank" rel="noopener noreferrer">.mcpb extension</a> from GitHub Releases</span>
         </li>
         <li class="flex gap-4">
           <span class="flex-shrink-0 text-xl font-light text-accent/30" aria-hidden="true">2</span>

--- a/website/src/components/WhySection.astro
+++ b/website/src/components/WhySection.astro
@@ -60,9 +60,9 @@ import { site } from '../data/site';
       </p>
       <a
         href={site.links.support}
-        class="inline-flex items-center gap-2 mt-4 rounded-full border border-border bg-white px-5 py-2 text-sm font-medium text-text-secondary shadow-sm hover:border-border-hover hover:text-text-primary transition-all"
+        class="cta-pill mt-4"
         target="_blank"
-        rel="noopener"
+        rel="noopener noreferrer"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-accent" fill="currentColor" viewBox="0 0 24 24" stroke="none" aria-hidden="true">
           <path d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z" />

--- a/website/src/components/WhySection.astro
+++ b/website/src/components/WhySection.astro
@@ -33,6 +33,7 @@ const items = [
     description: 'MIT licensed. Read every line, contribute, or fork.',
   },
 ];
+import { site } from '../data/site';
 ---
 
 <section class="py-14 sm:py-20">
@@ -51,6 +52,23 @@ const items = [
           <p class="text-sm text-text-secondary leading-relaxed mt-1">{item.description}</p>
         </div>
       ))}
+    </div>
+
+    <div class="mt-10 pt-8 border-t border-border text-center animate-on-scroll">
+      <p class="text-text-secondary text-sm leading-relaxed">
+        Built and maintained in personal time. If it saves you time, consider supporting its development.
+      </p>
+      <a
+        href={site.links.support}
+        class="inline-flex items-center gap-2 mt-4 rounded-full border border-border bg-white px-5 py-2 text-sm font-medium text-text-secondary shadow-sm hover:border-border-hover hover:text-text-primary transition-all"
+        target="_blank"
+        rel="noopener"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-accent" fill="currentColor" viewBox="0 0 24 24" stroke="none" aria-hidden="true">
+          <path d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z" />
+        </svg>
+        Support this project
+      </a>
     </div>
   </div>
 </section>

--- a/website/src/data/site.ts
+++ b/website/src/data/site.ts
@@ -15,6 +15,7 @@ export const site = {
     releases: 'https://github.com/vasylenko/bear-notes-mcp/releases',
     bearApp: 'https://bear.app',
     mcpSpec: 'https://modelcontextprotocol.io',
+    support: 'https://buymeacoffee.com/vasylenko',
   },
   install: {
     claudeDesktop: {

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -7,6 +7,7 @@ import FeatureGrid from '../components/FeatureGrid.astro';
 import UseCases from '../components/UseCases.astro';
 import InstallGuide from '../components/InstallGuide.astro';
 import FAQ from '../components/FAQ.astro';
+
 const cx = 'mx-auto max-w-5xl px-4 sm:px-6 lg:px-8';
 ---
 
@@ -41,5 +42,6 @@ const cx = 'mx-auto max-w-5xl px-4 sm:px-6 lg:px-8';
       <FAQ />
     </div>
   </div>
+
 
 </BaseLayout>

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -102,6 +102,26 @@
   outline-offset: 2px;
 }
 
+/* CTA pill buttons (footer, support) */
+.cta-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  background: var(--color-surface-1);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  padding: 8px 20px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  transition: all 0.2s;
+}
+.cta-pill:hover {
+  border-color: var(--color-border-hover);
+  color: var(--color-text-primary);
+}
+
 /* Trust signal pills */
 .trust-pill {
   display: inline-flex;


### PR DESCRIPTION
## Summary
- Adds a "Support this project" pill button to the website footer, displayed alongside the existing "Star on GitHub" button
- Adds a Buy Me a Coffee shields.io badge (matching the site accent color) to the README badges row
- Moves `FUNDING.yml` to `.github/FUNDING.yml` (canonical location) and adds `buy_me_a_coffee: vasylenko` alongside the existing GitHub Sponsors entry

## Why
Gives users who find the project useful a low-friction way to show support, both from the landing page and from the GitHub repo page.