### PR TITLE
feat: enhance note metadata in responses and add tests for tag functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **`bear-add-tag` and `bear-add-file` now return complete note metadata** — mutation tool responses previously had gaps: `bear-add-tag` omitted the note ID, and `bear-add-file` (when called with an ID) omitted the note title. Both tools now consistently return the note title and ID, matching all other mutation tools. This gives LLM clients the metadata they need for follow-up operations without an extra lookup step.
+
 ## [2.10.0] - 2026-04-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,19 +4,16 @@ MCP server for Bear Notes, distributed through two channels:
 - **MCP Bundle** (.mcpb) — a one-click installable extension for Claude Desktop. MCP Bundles are zip archives containing a local MCP server and a manifest.json, similar to Chrome extensions (.crx) or VS Code extensions (.vsix).
 - **npm package** (`bear-notes-mcp`) — a standalone MCP server for Claude Code, Cursor, Codex, and any other MCP client.
 
-# Your Role in this Project
+## Your Role in this Project
 You are world-class NodeJS developer, senior engineer with a vast experience in creating high-quality  customer-facing applications with high adoption rates that use AI capabilties, specifically MCP servers (but not limited to). You are wise and creative, you act with authority and decisiveness but strictly adhere to the rules described below. 
 
-# Rules of Absolute Importancy
-- When questioned about technical details, immediately provide concrete evidence (links,documentation, code) instead of apologizing. Be direct and factual. 
-- You are a seasoned TypeScript developer, and a wise engineer who knows NodeJS domain and associated technologies
+## Rules of Absolute Importance
 - KISS and DRY are your main development principles: you ensure that every change you make keeps the code easy to read and maintain:
     - when adding a new feature – you ensure the new code add exactly that functional requirement, nothing extra
     - when refactoring – you ensure that you simplify the maintenance and reduce lines of code (if possible)
-- All project dependencies must be managed ONLY through their respective CLI tools, and NEVER through editing package lock files.`
-- You always think few minutes before start coding to ensure you follow these rules of absolute importancy and code style guidelines described below
+- All project dependencies must be managed ONLY through their respective CLI tools, and NEVER through editing package lock files.
 
-# Code Style Guidelines
+## Code Style Guidelines
 - TypeScript: Strict type checking, ES modules, explicit return types
 - Naming: PascalCase for classes/types, camelCase for functions/variables; descriptive self-documenting names for functions and variables
 - Files: Lowercase with hyphens, test files with .test.ts suffix
@@ -25,14 +22,14 @@ You are world-class NodeJS developer, senior engineer with a vast experience in 
 - Formatting: 2-space indentation, semicolons required, single quotes preferred
 - Comments: JSDoc for public APIs, inline comments for complex logic; All comments, no matter for which part of the code, ALWAYS asnwer "why" behind the functions or code blocks, NEVER "what" or restaring the obvious - they are concise and helpful.
 
-# Core Technical Documentation for this project
+## Core Technical Documentation for this project
 - MCP TypeScript SDK - https://github.com/modelcontextprotocol/typescript-sdk/blob/main/README.md
 - MCPB (MCP Bundles) - https://github.com/anthropics/mcpb/blob/main/README.md
 - MCPB manifest.json specificaton - https://github.com/anthropics/mcpb/blob/main/MANIFEST.md
 - MCPB CLI - https://github.com/anthropics/mcpb/blob/main/CLI.md
 - Task automation system (build, test, pack, etc) - https://taskfile.dev/docs/guide 
 
-# Project Structure
+## Project Structure
 ```
 ├── src/                   # MCP server source code
 │   ├── main.ts            # Server entry point and tool registration
@@ -56,19 +53,19 @@ You are world-class NodeJS developer, senior engineer with a vast experience in 
 └── package.json           # Node.js dependencies and scripts
 ```
 
-# Additional technical context
+## Additional technical context
 
 1 - Project Specification - .claude/contexts/SPECIFICATION.md - read this before making architectural changes; covers system boundaries, design constraints, safety gates, and the rationale behind the hybrid read/write model
 
 2 - Bear database schema brief - .claude/contexts/BEAR_DATABASE_SCHEMA.md - use this when working with tasks related to database access as a starting point
 
-# Core Workflows
+## Core Workflows
 
-## Website
+### Website
 
 Promotional single-page landing at `bear-notes-mcp.vercel.app` (Vercel free domain, no custom domain). Built with Astro + Tailwind CSS, lives in `website/`. When adding or removing tools, update the tool count in `website/src/components/FeatureGrid.astro` alongside README.md and docs/NPM.md.
 
-## Release Process
+### Release Process
 
 All releases go through these steps in order. See `Taskfile.yml` for the underlying commands.
 
@@ -81,14 +78,25 @@ All releases go through these steps in order. See `Taskfile.yml` for the underly
 
 The release workflow (`release.yml`) builds the `.mcpb` bundle, creates a GitHub Release, and publishes to npm with provenance.
 
-# MCP Guideline – Tool Documentation Best Practices
-## Tool Description
+## MCP Standards
+
+### Separation of Concerns
+
+Tool descriptions help with tool selection and understanding, while schema descriptions guide proper usage.
+
+### LLM-First Design
+
+Design to optimize for LLM consumption patterns; tools are first discovered via descriptions then invoked via schemas.
+
+### Mutation Response Metadata
+
+Every note-level mutation tool must return **note ID + note title + what changed** in its response. Both values are always available without post-write database reads: the ID comes from the input parameter or creation polling, and the title comes from the pre-flight `getNoteContent()` validation. Never fetch tags or other metadata from the database after a write — Bear's fire-and-forget architecture means post-write reads return pre-mutation state, which would mislead the LLM into thinking the operation failed.
+
+### Tool Description
 The description field should provide a concise, high-level explanation of what the tool accomplishes:
 
 - Purpose: Communicate tool functionality and use cases, focus on user needs
-- Audience:
-    - LLMs who need select appropriate tools
-    - Developers who need to understand the tool capabilities
+- Audience - LLMs who need to select appropriate tools
 - Content Guidelines:
     - Avoid parameter-specific details
 
@@ -100,13 +108,11 @@ Example:
 }
 ```
 
-## Schema Descriptions
+### Schema Descriptions
 The inputSchema property descriptions should provide parameter-specific documentation:
 
 - Purpose: Guide correct tool invocation
-- Audience:
-    - LLMs constructing tool calls
-    - Developers implementing clients
+- Audience - LLMs constructing tool calls
 - Content Guidelines:
     - Specify parameter types and constraints
     - Include validation requirements
@@ -121,9 +127,3 @@ const schema = z.object({
     .describe("Array of file paths to read. Each path must be a valid absolute or relative file path.")
 });
 ```
-## Rationale
-Separation of Concerns: Tool descriptions and schema descriptions serve different purposes and audiences. Tool descriptions help with tool selection and understanding, while schema descriptions guide proper usage.
-
-Flexibility Over Prescription: The guidelines provide clear direction while allowing implementation flexibility, recognizing that different tools may have unique documentation needs.
-
-LLM-First Design: The practices optimize for LLM consumption patterns, where tools are first discovered via descriptions then invoked via schemas.

--- a/src/main.ts
+++ b/src/main.ts
@@ -551,6 +551,7 @@ server.registerTool(
       }
 
       // Fail fast with helpful message rather than cryptic Bear error
+      let noteTitle: string | undefined;
       if (id) {
         const existingNote = getNoteContent(id);
         if (!existingNote) {
@@ -558,6 +559,7 @@ server.registerTool(
 
 Use bear-search-notes to find the correct note identifier.`);
         }
+        noteTitle = existingNote.title;
       }
 
       const url = buildBearUrl('add-file', {
@@ -571,7 +573,8 @@ Use bear-search-notes to find the correct note identifier.`);
       logger.debug(`Executing Bear add-file URL for: ${resolvedFilename}`);
       await executeBearXCallbackApi(url);
 
-      const noteIdentifier = id ? `Note ID: ${id}` : `Note title: "${title!}"`;
+      // Title-only path omits ID: no pre-flight DB lookup, so ID is unavailable
+      const noteIdentifier = id ? `Note: "${noteTitle}"\nID: ${id}` : `Note: "${title!}"`;
 
       return createToolResponse(`File "${resolvedFilename}" added successfully!
 
@@ -763,6 +766,7 @@ Use bear-search-notes to find the correct note identifier.`);
       return createToolResponse(`Tags added successfully!
 
 Note: "${existingNote.title}"
+ID: ${id}
 Tags: ${tagList}
 
 The tags have been added to the beginning of the note.`);

--- a/tests/system/add-tag.test.ts
+++ b/tests/system/add-tag.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { callTool, cleanupTestNotes, findNoteId, trashNote, uniqueTitle } from './inspector.js';
+
+const TEST_PREFIX = '[Bear-MCP-stest-add-tag]';
+const RUN_ID = Date.now();
+
+afterAll(() => {
+  cleanupTestNotes(TEST_PREFIX);
+});
+
+describe('bear-add-tag via MCP Inspector CLI', () => {
+  it('returns note ID, title, and tag in response', () => {
+    const title = uniqueTitle(TEST_PREFIX, 'Single', RUN_ID);
+    let noteId: string | undefined;
+
+    try {
+      callTool({
+        toolName: 'bear-create-note',
+        args: { title, text: 'Add tag test note', tags: 'system-test' },
+      });
+
+      noteId = findNoteId(title);
+      const tag = `stest-add-tag-${RUN_ID}`;
+
+      const result = callTool({
+        toolName: 'bear-add-tag',
+        args: { id: noteId, tags: JSON.stringify([tag]) },
+      }).content[0].text;
+
+      expect(result).toContain('added successfully');
+      expect(result).toContain(title);
+      expect(result).toContain(noteId);
+      expect(result).toContain(`#${tag}`);
+    } finally {
+      if (noteId) trashNote(noteId);
+    }
+  });
+
+  it('lists all tags when multiple are added', () => {
+    const title = uniqueTitle(TEST_PREFIX, 'Multi', RUN_ID);
+    let noteId: string | undefined;
+
+    try {
+      callTool({
+        toolName: 'bear-create-note',
+        args: { title, text: 'Multi-tag test note', tags: 'system-test' },
+      });
+
+      noteId = findNoteId(title);
+      const tags = [`stest-add-tag-${RUN_ID}-a`, `stest-add-tag-${RUN_ID}-b`];
+
+      const result = callTool({
+        toolName: 'bear-add-tag',
+        args: { id: noteId, tags: JSON.stringify(tags) },
+      }).content[0].text;
+
+      expect(result).toContain(noteId);
+      expect(result).toContain(title);
+      for (const tag of tags) {
+        expect(result).toContain(`#${tag}`);
+      }
+    } finally {
+      if (noteId) trashNote(noteId);
+    }
+  });
+
+  it('returns error for non-existent note ID', () => {
+    const result = callTool({
+      toolName: 'bear-add-tag',
+      args: { id: '00000000-0000-0000-0000-000000000000', tags: '["bogus"]' },
+    }).content[0].text;
+
+    expect(result).toContain('not found');
+  });
+});

--- a/tests/system/attached-files.test.ts
+++ b/tests/system/attached-files.test.ts
@@ -277,9 +277,11 @@ describe('attached files content separation', () => {
         args: { id: noteId, file_path: OCR_JPG_PATH },
       }).content[0].text;
 
-      // Server should infer filename from path
+      // Server should infer filename from path and return complete metadata
       expect(addResult).toContain('ocr-text.jpg');
       expect(addResult).toContain('added successfully');
+      expect(addResult).toContain(title);
+      expect(addResult).toContain(noteId);
 
       // Poll until Bear finishes OCR — proves the file was actually attached
       const response = await waitForFileContent(noteId, 'simple');


### PR DESCRIPTION
All note-level mutation responses consistently include note ID + note title + what changed. These three fields are always available without post-write DB reads:

Note ID — passed as input parameter or resolved during creation

Note title — fetched during pre-flight getNoteContent() validation

What changed — known from the input parameters (tags added, text inserted, file attached, etc.)

Inspired by https://axi.md/

--
Resolves SVA-16