### PR TITLE
Mark bear-add-tag as idempotent based on empirical Bear API behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`bear-add-tag` correctly marked as idempotent** — the tool's MCP annotation now reflects that adding an already-present tag is a no-op. MCP clients can safely retry `bear-add-tag` calls on transient failures without risk of unintended side effects.
+
 ### Fixed
 - **`bear-add-tag` and `bear-add-file` now return complete note metadata** — mutation tool responses previously had gaps: `bear-add-tag` omitted the note ID, and `bear-add-file` (when called with an ID) omitted the note title. Both tools now consistently return the note title and ID, matching all other mutation tools. This gives LLM clients the metadata they need for follow-up operations without an extra lookup step.
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -733,7 +733,7 @@ server.registerTool(
     annotations: {
       readOnlyHint: false,
       destructiveHint: false,
-      idempotentHint: false,
+      idempotentHint: true,
       openWorldHint: true,
     },
   },

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -16,7 +16,7 @@ const POLL_TIMEOUT_MS = 2_000;
 // Safety window wider than POLL_TIMEOUT_MS to avoid matching a stale note with the same title
 const CREATION_LOOKBACK_MS = 10_000;
 
-// SQL equivalent of decodeTagName() in tags.ts — both MUST apply the same transformations
+// SQL equivalent of decodeTagName() in utils.ts — both MUST apply the same transformations
 const DECODED_TAG_TITLE = "LOWER(TRIM(REPLACE(t.ZTITLE, '+', ' ')))";
 
 /**

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -1,17 +1,6 @@
 import type { BearNote, BearTag } from './types.js';
-import { convertCoreDataTimestamp, logAndThrow, logger } from './utils.js';
+import { convertCoreDataTimestamp, decodeTagName, logAndThrow, logger } from './utils.js';
 import { closeBearDatabase, openBearDatabase } from './database.js';
-
-/**
- * Decodes and normalizes Bear tag names.
- * - Replaces '+' with spaces (Bear's URL encoding)
- * - Converts to lowercase (matches Bear UI behavior)
- * - Trims whitespace
- * Keep in sync with DECODED_TAG_TITLE in notes.ts — both MUST apply the same transformations.
- */
-function decodeTagName(encodedName: string): string {
-  return encodedName.replace(/\+/g, ' ').trim().toLowerCase();
-}
 
 /**
  * Extracts the display name (leaf) from a full tag path.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,7 +42,7 @@ export function logAndThrow(message: string): never {
  * Keep in sync with DECODED_TAG_TITLE in notes.ts — both MUST apply the same transformations.
  */
 export function decodeTagName(encodedName: string): string {
-  return encodedName.replace(/\+/g, ' ').trim().toLowerCase();
+  return encodedName.replaceAll('+', ' ').trim().toLowerCase();
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,6 +35,17 @@ export function logAndThrow(message: string): never {
 }
 
 /**
+ * Decodes and normalizes Bear tag names.
+ * - Replaces '+' with spaces (Bear's URL encoding)
+ * - Converts to lowercase (matches Bear UI behavior)
+ * - Trims whitespace
+ * Keep in sync with DECODED_TAG_TITLE in notes.ts — both MUST apply the same transformations.
+ */
+export function decodeTagName(encodedName: string): string {
+  return encodedName.replace(/\+/g, ' ').trim().toLowerCase();
+}
+
+/**
  * Cleans base64 string by removing whitespace/newlines added by base64 command.
  * URLSearchParams in buildBearUrl will handle URL encoding of special characters.
  *


### PR DESCRIPTION
## Summary
- Marks `bear-add-tag` tool annotation `idempotentHint` as `true` — Bear's `add-text` API with `tags` parameter already handles duplicate tags gracefully (no text duplication, no modification date change)
- Extracts `decodeTagName()` from `tags.ts` to `utils.ts` as a shared export, enabling reuse across modules (prerequisite for SVA-18)
- Updates the cross-reference comment in `notes.ts` to point to the new location in `utils.ts`

## Why
The `bear-add-tag` tool was annotated with `idempotentHint: false`, implying repeated calls could cause side effects. Empirical testing showed Bear's native behavior already prevents duplicate tag text — re-adding an existing tag is a no-op. Correcting the annotation lets MCP clients (especially LLMs) safely retry or re-issue tag operations without worrying about cosmetic duplication.

--
SVA-17