### PR TITLE
Include decoded tag names in search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`bear-search-notes` now includes tags in results** — each search result with tags shows a `Tags:` line alongside existing metadata (title, dates, ID). This lets LLMs cross-reference tags across multiple notes without opening each one individually.
+
 ### Changed
 - **`bear-add-tag` correctly marked as idempotent** — the tool's MCP annotation now reflects that adding an already-present tag is a no-op. MCP clients can safely retry `bear-add-tag` calls on transient failures without risk of unintended side effects.
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -226,7 +226,7 @@ server.registerTool(
   {
     title: 'Find Bear Notes',
     description:
-      'Find notes in your Bear library by searching text content, filtering by tags, or date ranges. Always searches within attached images and PDF files via OCR. Returns a list with titles and IDs - use "Open Bear Note" to read full content.',
+      'Find notes in your Bear library by searching text content, filtering by tags, or date ranges. Always searches within attached images and PDF files via OCR. Returns a list with titles, tags, and IDs - use "Open Bear Note" to read full content.',
     inputSchema: {
       term: z.string().trim().optional().describe('Text to search for in note titles and content'),
       tag: z.string().trim().optional().describe('Tag to filter notes by (without # symbol)'),

--- a/src/main.ts
+++ b/src/main.ts
@@ -329,6 +329,9 @@ Try different search criteria or check if notes exist in Bear Notes.`);
         resultLines.push(`${index + 1}. **${noteTitle}**`);
         resultLines.push(`   Created: ${createdDate}`);
         resultLines.push(`   Modified: ${modifiedDate}`);
+        if (note.tags && note.tags.length > 0) {
+          resultLines.push(`   Tags: ${note.tags.join(', ')}`);
+        }
         resultLines.push(`   ID: ${note.identifier}`);
         resultLines.push('');
       });

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -5,6 +5,7 @@ import { DEFAULT_SEARCH_LIMIT } from './config.js';
 import {
   convertCoreDataTimestamp,
   convertDateToCoreDataTimestamp,
+  decodeTagName,
   logAndThrow,
   logger,
   parseDateString,
@@ -43,6 +44,7 @@ function formatBearNote(row: Record<string, unknown>): BearNote {
   const creationDate = row.creationDate as number;
   const pinned = row.pinned as number | undefined;
   const text = row.text as string | undefined;
+  const rawTags = row.rawTags as string | undefined;
 
   if (!identifier) {
     logAndThrow('Database error: Note identifier is missing from database row');
@@ -57,12 +59,16 @@ function formatBearNote(row: Record<string, unknown>): BearNote {
   // Bear stores pinned as integer; API expects string literal (only needed when pinned is queried)
   const pin: 'yes' | 'no' = pinned ? 'yes' : 'no';
 
+  // Tags come from a correlated subquery as comma-separated encoded names (e.g., "+What+is+Gravity")
+  const tags = rawTags ? rawTags.split(',').map(decodeTagName) : undefined;
+
   return {
     title,
     identifier,
     modification_date,
     creation_date,
     pin,
+    ...(tags && { tags }),
     ...(text !== undefined && { text }),
   };
 }
@@ -259,7 +265,11 @@ export function searchNotes(
              note.ZUNIQUEIDENTIFIER as identifier,
              note.ZCREATIONDATE as creationDate,
              note.ZMODIFICATIONDATE as modificationDate,
-             note.ZPINNED as pinned
+             note.ZPINNED as pinned,
+             (SELECT GROUP_CONCAT(t2.ZTITLE, ',')
+              FROM Z_5TAGS nt2
+              JOIN ZSFNOTETAG t2 ON t2.Z_PK = nt2.Z_13TAGS
+              WHERE nt2.Z_5NOTES = note.Z_PK) as rawTags
       FROM ZSFNOTE note
       LEFT JOIN ZSFNOTEFILE f ON f.ZNOTE = note.Z_PK`;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export interface BearNote {
   modification_date: string;
   creation_date: string;
   pin: 'yes' | 'no';
+  tags?: string[]; // Only present in search results
   text?: string; // Only present in content queries
   files?: AttachedFile[]; // Only present in getNoteContent()
 }

--- a/tests/system/tag-search.test.ts
+++ b/tests/system/tag-search.test.ts
@@ -20,6 +20,9 @@ const TITLE_EXACT = title('Exact');
 const TITLE_NESTED = title('Nested');
 const TITLE_SIMILAR = title('Similar');
 const TITLE_UNTAGGED = title('Untagged');
+// Tag with a space exercises decodeTagName() — Bear stores it as "+"-encoded in ZTITLE
+const TAG_SPACED = `stest67 spaced ${RUN_ID}`;
+const TITLE_SPACED = title('Spaced');
 
 const noteIds: string[] = [];
 
@@ -36,6 +39,10 @@ beforeAll(() => {
     callTool({ toolName: 'bear-create-note', args: { title: noteTitle, tags: tag } });
     noteIds.push(findNoteId(noteTitle));
   }
+
+  // Note with space-containing tag to exercise decodeTagName()
+  callTool({ toolName: 'bear-create-note', args: { title: TITLE_SPACED, tags: TAG_SPACED } });
+  noteIds.push(findNoteId(TITLE_SPACED));
 
   // Untagged note for verifying Tags: line absence
   callTool({ toolName: 'bear-create-note', args: { title: TITLE_UNTAGGED, text: 'No tags here' } });
@@ -112,6 +119,17 @@ describe('tag search via MCP Inspector CLI', () => {
     expect(result).toContain('Tags:');
     expect(result).toContain(TAG_BASE);
     expect(result).toContain(TAG_NESTED);
+  });
+
+  it('tags with spaces are decoded from Bear internal encoding', () => {
+    const result = callTool({
+      toolName: 'bear-search-notes',
+      args: { term: TITLE_SPACED },
+    }).content[0].text;
+
+    // Bear stores spaces as "+" in ZTITLE — decodeTagName() must convert back
+    expect(result).toContain(TAG_SPACED);
+    expect(result).not.toContain('+');
   });
 
   it('untagged notes omit the Tags line in search results', () => {

--- a/tests/system/tag-search.test.ts
+++ b/tests/system/tag-search.test.ts
@@ -19,6 +19,7 @@ function title(label: string): string {
 const TITLE_EXACT = title('Exact');
 const TITLE_NESTED = title('Nested');
 const TITLE_SIMILAR = title('Similar');
+const TITLE_UNTAGGED = title('Untagged');
 
 const noteIds: string[] = [];
 
@@ -35,6 +36,10 @@ beforeAll(() => {
     callTool({ toolName: 'bear-create-note', args: { title: noteTitle, tags: tag } });
     noteIds.push(findNoteId(noteTitle));
   }
+
+  // Untagged note for verifying Tags: line absence
+  callTool({ toolName: 'bear-create-note', args: { title: TITLE_UNTAGGED, text: 'No tags here' } });
+  noteIds.push(findNoteId(TITLE_UNTAGGED));
 });
 
 afterAll(() => {
@@ -107,5 +112,15 @@ describe('tag search via MCP Inspector CLI', () => {
     expect(result).toContain('Tags:');
     expect(result).toContain(TAG_BASE);
     expect(result).toContain(TAG_NESTED);
+  });
+
+  it('untagged notes omit the Tags line in search results', () => {
+    const result = callTool({
+      toolName: 'bear-search-notes',
+      args: { term: TITLE_UNTAGGED },
+    }).content[0].text;
+
+    expect(result).toContain(TITLE_UNTAGGED);
+    expect(result).not.toContain('Tags:');
   });
 });

--- a/tests/system/tag-search.test.ts
+++ b/tests/system/tag-search.test.ts
@@ -94,4 +94,18 @@ describe('tag search via MCP Inspector CLI', () => {
     expect(result).not.toContain(TITLE_EXACT);
     expect(result).not.toContain(TITLE_NESTED);
   });
+
+  it('search results include decoded tag names', () => {
+    const result = callTool({
+      toolName: 'bear-search-notes',
+      args: { tag: TAG_BASE },
+    }).content[0].text;
+
+    // Verify the Tags: line exists and contains decoded tag names.
+    // Bear auto-assigns parent tags to nested-tagged notes, so the "Nested" note
+    // has both TAG_BASE and TAG_NESTED — match each tag independently.
+    expect(result).toContain('Tags:');
+    expect(result).toContain(TAG_BASE);
+    expect(result).toContain(TAG_NESTED);
+  });
 });


### PR DESCRIPTION
## Summary
- `bear-search-notes` now returns decoded tag names alongside each search result, showing a `Tags:` line between Modified and ID for notes that have tags
- Untagged notes omit the `Tags:` line entirely, keeping output clean
- Tags are fetched in the same database query (correlated subquery), so there is no additional round-trip per note

## Why
Tag cross-referencing previously required opening every note individually -- one follow-up call per note. Including tags directly in search results eliminates those N extra calls, making tag-based filtering and organization possible in a single search.

--
Linear: SVA-18
