### PR TITLE
feat: use isError flag for soft error responses

### DIFF
--- a/.claude/contexts/SPECIFICATION.md
+++ b/.claude/contexts/SPECIFICATION.md
@@ -91,12 +91,14 @@ Two tiers of errors, from the client's perspective:
 
 | Tier | When | What the client sees |
 |------|------|---------------------|
-| Soft error | Expected condition (note not found, section missing, feature disabled) | Normal text response describing the problem and suggesting a fix |
-| Hard error | Unexpected failure (subprocess crash, DB error) | MCP-level error response |
+| Soft error | Expected condition (note not found, section missing, feature disabled, parameter validation, file errors) | `isError: true` response with text describing the problem and suggesting a fix |
+| Hard error | Unexpected failure (subprocess crash, DB error) | MCP-level error response (thrown exception) |
 
-Note-level write tools do pre-flight DB validation to turn silent Bear failures into clear soft errors. Global tag operations cannot be pre-validated.
+The classification boundary is: **"Did the tool accomplish what it was asked to do?"** If yes (even with zero results), it stays a normal response via `createToolResponse()`. If no, it becomes `isError: true` via `createErrorResponse()`.
 
-Neither tier uses the MCP SDK's `isError` field — this is a potential future improvement.
+Normal responses (not errors): empty search results, no tags found, no untagged notes, title disambiguation — these are correct answers, not failures.
+
+Note-level write tools do pre-flight DB validation to turn silent Bear failures into clear soft errors. Global tag operations cannot be pre-validated. Permanent conditions (e.g., feature disabled) include explicit non-retryability language to prevent LLM retry loops.
 
 ---
 

--- a/.claude/contexts/SPECIFICATION.md
+++ b/.claude/contexts/SPECIFICATION.md
@@ -91,8 +91,8 @@ Two tiers of errors, from the client's perspective:
 
 | Tier | When | What the client sees |
 |------|------|---------------------|
-| Soft error | Expected condition (note not found, section missing, feature disabled, parameter validation, file errors) | `isError: true` response with text describing the problem and suggesting a fix |
-| Hard error | Unexpected failure (subprocess crash, DB error) | MCP-level error response (thrown exception) |
+| Soft error | Expected condition handled inside tool handlers (note not found, section missing, feature disabled, handler-level parameter validation, file errors) | `isError: true` response with text describing the problem and suggesting a fix |
+| Hard error | Unexpected failure or deep validation error (subprocess crash, DB error, invalid date format) | MCP-level error response (thrown exception — SDK wraps these in `isError: true` automatically) |
 
 The classification boundary is: **"Did the tool accomplish what it was asked to do?"** If yes (even with zero results), it stays a normal response via `createToolResponse()`. If no, it becomes `isError: true` via `createErrorResponse()`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`bear-search-notes` now includes tags in results** — each search result with tags shows a `Tags:` line alongside existing metadata (title, dates, ID). This lets LLMs cross-reference tags across multiple notes without opening each one individually.
 
 ### Changed
+- **Soft errors now signal `isError: true` in tool responses** — when a tool call fails due to a missing note, invalid parameters, a disabled feature, or a file error, the MCP response now sets `isError: true` instead of returning the error message as a normal result. This lets MCP clients distinguish failures from successful empty results (like "no notes found") and gives LLMs a clear signal to self-correct. Permanent conditions (e.g., feature disabled) include explicit "do not retry" guidance.
 - **`bear-add-tag` correctly marked as idempotent** — the tool's MCP annotation now reflects that adding an already-present tag is a no-op. MCP clients can safely retry `bear-add-tag` calls on transient failures without risk of unintended side effects.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`bear-search-notes` now includes tags in results** — each search result with tags shows a `Tags:` line alongside existing metadata (title, dates, ID). This lets LLMs cross-reference tags across multiple notes without opening each one individually.
 
 ### Changed
-- **Soft errors now signal `isError: true` in tool responses** — when a tool call fails due to a missing note, invalid parameters, a disabled feature, or a file error, the MCP response now sets `isError: true` instead of returning the error message as a normal result. This lets MCP clients distinguish failures from successful empty results (like "no notes found") and gives LLMs a clear signal to self-correct. Permanent conditions (e.g., feature disabled) include explicit "do not retry" guidance.
+- **Soft errors now signal `isError: true` in tool responses** — for recoverable failures handled inside tool implementations (such as a missing note, handler-level parameter validation, a disabled feature, or a file error), the tool response now sets `isError: true` instead of returning the error message as a normal result. This lets MCP clients distinguish failures from successful empty results (like "no notes found") and gives LLMs a clear signal to self-correct. Permanent conditions (e.g., feature disabled) include explicit "do not retry" guidance.
 - **`bear-add-tag` correctly marked as idempotent** — the tool's MCP annotation now reflects that adding an already-present tag is a no-op. MCP clients can safely retry `bear-add-tag` calls on transient failures without risk of unintended side effects.
 
 ### Fixed

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,13 @@ import { z } from 'zod';
 
 import { APP_VERSION, ENABLE_CONTENT_REPLACEMENT, ENABLE_NEW_NOTE_CONVENTIONS } from './config.js';
 import { applyNoteConventions } from './note-conventions.js';
-import { cleanBase64, createToolResponse, handleNoteTextUpdate, logger } from './utils.js';
+import {
+  cleanBase64,
+  createErrorResponse,
+  createToolResponse,
+  handleNoteTextUpdate,
+  logger,
+} from './utils.js';
 import { awaitNoteCreation, findNotesByTitle, getNoteContent, searchNotes } from './notes.js';
 import { findUntaggedNotes, listTags } from './tags.js';
 import { buildBearUrl, executeBearXCallbackApi } from './bear-urls.js';
@@ -67,7 +73,7 @@ server.registerTool(
     );
 
     if (!id && !title) {
-      return createToolResponse(
+      return createErrorResponse(
         'Either note ID or title is required. Use bear-search-notes to find the note ID, or provide the exact title.'
       );
     }
@@ -78,7 +84,7 @@ server.registerTool(
         const matches = findNotesByTitle(title);
 
         if (matches.length === 0) {
-          return createToolResponse(`No note found with title "${title}". The note may have been deleted, archived, or the title may be different.
+          return createErrorResponse(`No note found with title "${title}". The note may have been deleted, archived, or the title may be different.
 
 Use bear-search-notes to find notes by partial text match.`);
         }
@@ -102,7 +108,7 @@ Use bear-open-note with a specific ID to open the desired note.`);
       const noteWithContent = getNoteContent(id!);
 
       if (!noteWithContent) {
-        return createToolResponse(`Note with ID '${id}' not found. The note may have been deleted, archived, or the ID may be incorrect.
+        return createErrorResponse(`Note with ID '${id}' not found. The note may have been deleted, archived, or the ID may be incorrect.
 
 Use bear-search-notes to find the correct note identifier.`);
       }
@@ -435,19 +441,19 @@ server.registerTool(
   },
   async ({ id, scope, text, header }): Promise<CallToolResult> => {
     if (!ENABLE_CONTENT_REPLACEMENT) {
-      return createToolResponse(`Content replacement is not enabled.
+      return createErrorResponse(`Content replacement is not enabled. Do not retry — this requires a settings change by the user.
 
-To use replace mode, enable "Content Replacement" in the Bear Notes server settings.`);
+To use replace mode, the user must enable "Content Replacement" in the Bear Notes server settings.`);
     }
 
     if (scope === 'section' && !header) {
-      return createToolResponse(`scope is "section" but no header was provided.
+      return createErrorResponse(`scope is "section" but no header was provided.
 
 Set the header parameter to the section heading you want to replace.`);
     }
 
     if (scope === 'full-note-body' && header) {
-      return createToolResponse(`scope is "full-note-body" but a header was provided.
+      return createErrorResponse(`scope is "full-note-body" but a header was provided.
 
 Remove the header parameter to replace the full note body, or change scope to "section".`);
     }
@@ -507,19 +513,19 @@ server.registerTool(
     );
 
     if (!id && !title) {
-      return createToolResponse(
+      return createErrorResponse(
         'Either note ID or title is required. Use bear-search-notes to find the note ID.'
       );
     }
 
     if (file_path && base64_content) {
-      return createToolResponse('Provide either file_path or base64_content, not both.');
+      return createErrorResponse('Provide either file_path or base64_content, not both.');
     }
     if (!file_path && !base64_content) {
-      return createToolResponse('Either file_path or base64_content is required.');
+      return createErrorResponse('Either file_path or base64_content is required.');
     }
     if (base64_content && !filename) {
-      return createToolResponse('filename is required when using base64_content.');
+      return createErrorResponse('filename is required when using base64_content.');
     }
 
     try {
@@ -531,18 +537,18 @@ server.registerTool(
         try {
           const buffer = readFileSync(file_path);
           if (buffer.length === 0) {
-            return createToolResponse(`File is empty: ${file_path}`);
+            return createErrorResponse(`File is empty: ${file_path}`);
           }
           fileData = buffer.toString('base64');
         } catch (err) {
           const code = (err as { code?: string }).code;
           if (code === 'ENOENT') {
-            return createToolResponse(`File not found: ${file_path}`);
+            return createErrorResponse(`File not found: ${file_path}`);
           }
           if (code === 'EACCES') {
-            return createToolResponse(`Permission denied: ${file_path}`);
+            return createErrorResponse(`Permission denied: ${file_path}`);
           }
-          return createToolResponse(
+          return createErrorResponse(
             `Cannot read file: ${err instanceof Error ? err.message : String(err)}`
           );
         }
@@ -558,7 +564,7 @@ server.registerTool(
       if (id) {
         const existingNote = getNoteContent(id);
         if (!existingNote) {
-          return createToolResponse(`Note with ID '${id}' not found. The note may have been deleted, archived, or the ID may be incorrect.
+          return createErrorResponse(`Note with ID '${id}' not found. The note may have been deleted, archived, or the ID may be incorrect.
 
 Use bear-search-notes to find the correct note identifier.`);
         }
@@ -746,7 +752,7 @@ server.registerTool(
     try {
       const existingNote = getNoteContent(id);
       if (!existingNote) {
-        return createToolResponse(`Note with ID '${id}' not found. The note may have been deleted, archived, or the ID may be incorrect.
+        return createErrorResponse(`Note with ID '${id}' not found. The note may have been deleted, archived, or the ID may be incorrect.
 
 Use bear-search-notes to find the correct note identifier.`);
       }
@@ -806,7 +812,7 @@ server.registerTool(
     try {
       const existingNote = getNoteContent(id);
       if (!existingNote) {
-        return createToolResponse(`Note with ID '${id}' not found. The note may have been deleted, archived, or the ID may be incorrect.
+        return createErrorResponse(`Note with ID '${id}' not found. The note may have been deleted, archived, or the ID may be incorrect.
 
 Use bear-search-notes to find the correct note identifier.`);
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -169,16 +169,7 @@ export function createToolResponse(text: string): Pick<CallToolResult, 'content'
  * @returns Formatted CallToolResult with isError: true
  */
 export function createErrorResponse(text: string): Pick<CallToolResult, 'content' | 'isError'> {
-  return {
-    content: [
-      {
-        type: 'text' as const,
-        text,
-        annotations: { audience: ['user', 'assistant'] as const },
-      },
-    ],
-    isError: true,
-  };
+  return { ...createToolResponse(text), isError: true };
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -160,6 +160,28 @@ export function createToolResponse(text: string): Pick<CallToolResult, 'content'
 }
 
 /**
+ * Creates a standardized MCP error response with isError flag.
+ * Signals to the LLM that the tool failed and self-correction may be needed.
+ * Per the MCP spec, tool errors use isError: true inside the result object
+ * so the LLM can see the failure and retry or adjust its approach.
+ *
+ * @param text - The error description with recovery guidance
+ * @returns Formatted CallToolResult with isError: true
+ */
+export function createErrorResponse(text: string): Pick<CallToolResult, 'content' | 'isError'> {
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text,
+        annotations: { audience: ['user', 'assistant'] as const },
+      },
+    ],
+    isError: true,
+  };
+}
+
+/**
  * Strips a matching markdown heading from the start of text to prevent header duplication.
  * Bear's add-text API with mode=replace keeps the original section header, so if the
  * replacement text also starts with that header, it appears twice in the note.
@@ -209,7 +231,7 @@ export async function handleNoteTextUpdate(
     const existingNote = getNoteContent(id);
 
     if (!existingNote) {
-      return createToolResponse(`Note with ID '${id}' not found. The note may have been deleted, archived, or the ID may be incorrect.
+      return createErrorResponse(`Note with ID '${id}' not found. The note may have been deleted, archived, or the ID may be incorrect.
 
 Use bear-search-notes to find the correct note identifier.`);
     }
@@ -220,7 +242,7 @@ Use bear-search-notes to find the correct note identifier.`);
     // Bear silently ignores replace-with-header when the section doesn't exist — fail early with a clear message
     if (mode === 'replace' && cleanHeader) {
       if (!existingNote.text || !noteHasHeader(existingNote.text, cleanHeader)) {
-        return createToolResponse(`Section "${cleanHeader}" not found in note "${existingNote.title}".
+        return createErrorResponse(`Section "${cleanHeader}" not found in note "${existingNote.title}".
 
 Check the note content with bear-open-note to see available sections.`);
       }

--- a/tests/system/add-tag.test.ts
+++ b/tests/system/add-tag.test.ts
@@ -66,11 +66,12 @@ describe('bear-add-tag via MCP Inspector CLI', () => {
   });
 
   it('returns error for non-existent note ID', () => {
-    const result = callTool({
+    const response = callTool({
       toolName: 'bear-add-tag',
       args: { id: '00000000-0000-0000-0000-000000000000', tags: '["bogus"]' },
-    }).content[0].text;
+    });
 
-    expect(result).toContain('not found');
+    expect(response.content[0].text).toContain('not found');
+    expect(response.isError).toBe(true);
   });
 });

--- a/tests/system/attached-files.test.ts
+++ b/tests/system/attached-files.test.ts
@@ -332,12 +332,13 @@ describe('attached files content separation', () => {
 
       noteId = findNoteId(title);
 
-      const result = callTool({
+      const response = callTool({
         toolName: 'bear-add-file',
         args: { id: noteId, file_path: '/tmp/does-not-exist-12345.pdf' },
-      }).content[0].text;
+      });
 
-      expect(result).toContain('File not found');
+      expect(response.content[0].text).toContain('File not found');
+      expect(response.isError).toBe(true);
     } finally {
       if (noteId) trashNote(noteId);
     }

--- a/tests/system/inspector.ts
+++ b/tests/system/inspector.ts
@@ -17,6 +17,7 @@ interface CallToolOptions {
 
 export interface ToolResponse {
   content: { type: string; text: string }[];
+  isError?: boolean;
 }
 
 /**

--- a/tests/system/open-note-by-title.test.ts
+++ b/tests/system/open-note-by-title.test.ts
@@ -72,12 +72,13 @@ describe('bear-open-note by title', () => {
   });
 
   it('returns not-found error for non-existent title', () => {
-    const openResult = callTool({
+    const response = callTool({
       toolName: 'bear-open-note',
       args: { title: `Non-existent note ${RUN_ID}` },
-    }).content[0].text;
+    });
 
-    expect(openResult).toContain('No note found with title');
+    expect(response.content[0].text).toContain('No note found with title');
+    expect(response.isError).toBe(true);
   });
 
   it('returns disambiguation list when multiple notes share the same title', () => {
@@ -121,12 +122,13 @@ describe('bear-open-note by title', () => {
   });
 
   it('returns error when neither id nor title is provided', () => {
-    const openResult = callTool({
+    const response = callTool({
       toolName: 'bear-open-note',
       args: {},
-    }).content[0].text;
+    });
 
-    expect(openResult).toContain('Either note ID or title is required');
+    expect(response.content[0].text).toContain('Either note ID or title is required');
+    expect(response.isError).toBe(true);
   });
 
   it('excludes trashed notes from title lookup', () => {

--- a/tests/system/replace-text.test.ts
+++ b/tests/system/replace-text.test.ts
@@ -169,13 +169,14 @@ describe('bear-replace-text via MCP Inspector CLI', () => {
 
       noteId = findNoteId(title);
 
-      const result = callTool({
+      const response = callTool({
         toolName: 'bear-replace-text',
         args: { id: noteId, scope: 'full-note-body', text: 'new content' },
         env: {},
-      }).content[0].text;
+      });
 
-      expect(result).toContain('Content replacement is not enabled');
+      expect(response.content[0].text).toContain('Content replacement is not enabled');
+      expect(response.isError).toBe(true);
     } finally {
       if (noteId) trashNote(noteId);
     }
@@ -352,13 +353,14 @@ describe('bear-replace-text via MCP Inspector CLI', () => {
 
       noteId = findNoteId(title);
 
-      const result = callTool({
+      const response = callTool({
         toolName: 'bear-replace-text',
         args: { id: noteId, scope: 'section', text: 'new content' },
         env: { UI_ENABLE_CONTENT_REPLACEMENT: 'true' },
-      }).content[0].text;
+      });
 
-      expect(result).toContain('scope is "section" but no header was provided');
+      expect(response.content[0].text).toContain('scope is "section" but no header was provided');
+      expect(response.isError).toBe(true);
     } finally {
       if (noteId) trashNote(noteId);
     }
@@ -376,13 +378,16 @@ describe('bear-replace-text via MCP Inspector CLI', () => {
 
       noteId = findNoteId(title);
 
-      const result = callTool({
+      const response = callTool({
         toolName: 'bear-replace-text',
         args: { id: noteId, scope: 'full-note-body', text: 'new content', header: 'Section' },
         env: { UI_ENABLE_CONTENT_REPLACEMENT: 'true' },
-      }).content[0].text;
+      });
 
-      expect(result).toContain('scope is "full-note-body" but a header was provided');
+      expect(response.content[0].text).toContain(
+        'scope is "full-note-body" but a header was provided'
+      );
+      expect(response.isError).toBe(true);
     } finally {
       if (noteId) trashNote(noteId);
     }

--- a/tests/system/replace-text.test.ts
+++ b/tests/system/replace-text.test.ts
@@ -193,13 +193,14 @@ describe('bear-replace-text via MCP Inspector CLI', () => {
 
       noteId = findNoteId(title);
 
-      const result = callTool({
+      const response = callTool({
         toolName: 'bear-replace-text',
         args: { id: noteId, scope: 'section', text: 'new content', header: 'NonExistentSection' },
         env: { UI_ENABLE_CONTENT_REPLACEMENT: 'true' },
-      }).content[0].text;
+      });
 
-      expect(result).toContain('"NonExistentSection" not found');
+      expect(response.content[0].text).toContain('"NonExistentSection" not found');
+      expect(response.isError).toBe(true);
     } finally {
       if (noteId) trashNote(noteId);
     }

--- a/tests/system/tag-search.test.ts
+++ b/tests/system/tag-search.test.ts
@@ -65,7 +65,7 @@ describe('tag search via MCP Inspector CLI', () => {
 
     expect(response.content[0].text).toContain(TITLE_EXACT);
     // Successful search must not be flagged as error — isError is only for tool failures
-    expect(response.isError).toBeUndefined();
+    expect(response.isError).not.toBe(true);
   });
 
   it('parent tag search includes notes with nested child tags', () => {

--- a/tests/system/tag-search.test.ts
+++ b/tests/system/tag-search.test.ts
@@ -58,12 +58,14 @@ afterAll(() => {
 
 describe('tag search via MCP Inspector CLI', () => {
   it('exact tag returns the matching note', () => {
-    const result = callTool({
+    const response = callTool({
       toolName: 'bear-search-notes',
       args: { tag: TAG_BASE },
-    }).content[0].text;
+    });
 
-    expect(result).toContain(TITLE_EXACT);
+    expect(response.content[0].text).toContain(TITLE_EXACT);
+    // Successful search must not be flagged as error — isError is only for tool failures
+    expect(response.isError).toBeUndefined();
   });
 
   it('parent tag search includes notes with nested child tags', () => {


### PR DESCRIPTION
## Summary
- When a tool call fails (note not found, invalid parameters, feature disabled, file errors), the MCP response now includes `isError: true` — giving LLMs a formal signal to self-correct instead of treating error text as "odd-looking data"
- When a tool call succeeds but returns empty results (no search matches, no tags, no untagged notes) or disambiguation data (multiple title matches), the response remains a normal result — these are correct answers, not failures
- The feature-disabled error in `bear-replace-text` now includes explicit "do not retry" guidance to prevent LLM retry loops on permanent conditions
- 19 error sites across all tools are flagged; 4 normal-response sites are intentionally unchanged

## Why
The MCP specification states that tool errors should use `isError: true` inside the result object so the LLM can see the failure and self-correct. Without it, Claude's built-in retry logic doesn't trigger, and self-correction is weaker because the LLM must infer failure from text alone.

--
Closes SVA-15