### PR TITLE
docs: weekly review 2026-04-15

### DIFF
--- a/.claude/contexts/SPECIFICATION.md
+++ b/.claude/contexts/SPECIFICATION.md
@@ -60,7 +60,7 @@ There is no delete tool. Too destructive for AI-assisted workflows — a misiden
 
 ### Bear's Database
 
-Bear uses Core Data with SQLite. The schema is undocumented — our understanding comes from reverse-engineering (see `BEAR_DATABASE_SCHEMA.md`). The database path is discovered via Bear's app container at `~/Library/Group Containers/group.com.shinyfrog.bear/`. Key fragility points:
+Bear uses Core Data with SQLite. The schema is undocumented — our understanding comes from reverse-engineering (see `BEAR_DATABASE_SCHEMA.md`). The database path is hardcoded to Bear's app group container at `~/Library/Group Containers/9K33E3U3T4.net.shinyfrog.bear/Application Data/database.sqlite` (overridable via `BEAR_DB_PATH` env var for tests). Key fragility points:
 
 - Tag name decoding logic exists in two places (SQL expression in `notes.ts` and TypeScript function in `tags.ts`) — these must produce identical results. Bidirectional comments link them.
 - Tag hierarchy is not stored relationally — it's reconstructed at query time by splitting slash-delimited paths.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Example prompts:
 
 **Prerequisites**: [Bear app](https://bear.app/) must be installed and [Claude Desktop](https://claude.ai/download) must be installed.
 
-1. Download the latest `bear-notes-mcpb.mcpb` extension from [Releases](https://github.com/vasylenko/bear-notes-mcp/releases)
+1. Download the latest `bear-notes-mcpb-*.mcpb` extension file from [Releases](https://github.com/vasylenko/bear-notes-mcp/releases)
 2. Make sure your Claude Desktop is running (start if not)
 3. Doubleclick on the extension file – Claude Desktop should show you the installation prompt
 


### PR DESCRIPTION
## Summary

Weekly documentation review against the current codebase. Two factual inaccuracies found and fixed: the Bear database path documented in `SPECIFICATION.md` was wrong (used the legacy `group.com.shinyfrog.bear` container path and described the path as "discovered" when it is actually a hardcoded constant), and the README's Claude Desktop install step pointed users at a static `bear-notes-mcpb.mcpb` filename even though the release pipeline produces date-stamped artifacts (`bear-notes-mcpb-YYYYMMDD.mcpb`).

## Changes

- [x] **Bear database path in SPECIFICATION.md** — the spec said the path is *"discovered via Bear's app container at `~/Library/Group Containers/group.com.shinyfrog.bear/`"*, but `src/config.ts` hardcodes `Library/Group Containers/9K33E3U3T4.net.shinyfrog.bear/Application Data/database.sqlite`. Updated to the actual path and noted the `BEAR_DB_PATH` test override that exists in `src/database.ts`.
- [x] **MCPB extension filename in README.md** — install step said *"Download the latest `bear-notes-mcpb.mcpb`"*, but `Taskfile.yml` (`BUNDLE_NAME: bear-notes-mcpb-{{now | date "20060102"}}.mcpb`) and `.github/workflows/release.yml` (`PACKAGE_PATTERN: bear-notes-mcpb-*.mcpb`) produce date-stamped filenames. Replaced the literal name with the `bear-notes-mcpb-*.mcpb` glob users actually see on the Releases page.

## No Issues Found

- **Tool reference accuracy** — 13 `server.registerTool(...)` calls in `src/main.ts` match the "13 MCP tools" claim in both `README.md` and `docs/NPM.md`. The `manifest.json` `tools` array names and descriptions match the registered tools, and the auto-synced sections in both docs (between `<!-- TOOLS:START -->` / `<!-- TOOLS:END -->`) are already in sync with `manifest.json`.
- **Configuration options** — `src/config.ts` and `src/utils.ts` only read three user-facing env vars (`UI_DEBUG_TOGGLE`, `UI_ENABLE_NEW_NOTE_CONVENTION`, `UI_ENABLE_CONTENT_REPLACEMENT`), all documented in README.md, docs/NPM.md, and `manifest.json` `user_config` with correct defaults. The internal/test-only `BEAR_DB_PATH` is correctly undocumented in the user-facing surface.
- **Feature behavior descriptions** — tool schemas, opt-in gating for `bear-replace-text` (via `ENABLE_CONTENT_REPLACEMENT`), the new-note-convention layout (`tagLine\n---\nbody` from `src/note-conventions.ts`), and date filter strings shown in `bear-search-notes` schema all match the implementation.
- **Installation and setup** — Node.js requirement (`>=24.13.0`) is consistent across `package.json` `engines`, `manifest.json` `compatibility.runtimes`, README.md, and docs/NPM.md. The `bear-notes-mcp` binary name matches `package.json` `bin`. JSON config snippets parse cleanly.
- **SPECIFICATION.md (other sections)** — hybrid read/write model, fire-and-forget write semantics, opt-in content replacement gate, no-delete safety policy, intentional exclusions (encrypted notes, per-tag pinning writes, write verification), and the soft/hard error handling contract all reflect current code.
- **Changelog consistency** — latest released version `[2.10.0]` matches `package.json` and `src/config.ts` `APP_VERSION`. The `[Unreleased]` entries (tags in search results, `isError: true` for soft errors, `bear-add-tag` idempotent annotation, mutation response metadata for `bear-add-tag`/`bear-add-file`) line up with recent commits (`ed89da8`, `d40d51b`, `62beea1`, `16c7bc6`).
- **Cross-document consistency** — tool count, env var names/defaults, and Node.js version requirement are consistent across README.md, docs/NPM.md, manifest.json, and SPECIFICATION.md.