### PR TITLE
security: gate bear-add-file and bear-grab-url behind opt-in toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,60 @@ Example standalone configuration with content replacement enabled:
 }
 ```
 
+### File Attachment
+
+Enable the `bear-add-file` tool to attach files from disk to Bear notes.
+
+> [!WARNING]
+> This feature is **disabled by default** for security reasons. When enabled, the AI can read any file path it is given and attach it to a note — with no path restrictions. If you paste untrusted content into Bear (e.g. a webpage fetched via `bear-grab-url`) while this server is connected, a prompt-injected instruction could cause the AI to read a sensitive file (such as `~/.ssh/id_rsa`) and attach it to a note where you could then read it back.
+>
+> Only enable this if you understand and accept the risk.
+
+- **Claude Desktop**: Settings → Extensions → Configure (next to Bear Notes) → toggle "File Attachment" → Save → Restart Claude
+- **Standalone MCP server**: set environment variable `UI_ENABLE_FILE_ATTACHMENT=true`
+
+Example standalone configuration with file attachment enabled:
+```json
+{
+  "mcpServers": {
+    "bear-notes": {
+      "command": "npx",
+      "args": ["-y", "bear-notes-mcp@latest"],
+      "env": {
+        "UI_ENABLE_FILE_ATTACHMENT": "true"
+      }
+    }
+  }
+}
+```
+
+### URL Grabbing
+
+Enable the `bear-grab-url` tool to save web pages as Bear notes.
+
+> [!WARNING]
+> This feature is **disabled by default** for security reasons. When enabled, the AI can cause your machine to make outbound HTTP(S) requests to arbitrary URLs via Bear — including addresses on your local network.
+>
+> Only enable this if you understand and accept the risk.
+
+- **Claude Desktop**: Settings → Extensions → Configure (next to Bear Notes) → toggle "URL Grabbing" → Save → Restart Claude
+- **Standalone MCP server**: set environment variable `UI_ENABLE_URL_GRAB=true`
+
+Example standalone configuration with URL grabbing enabled:
+```json
+{
+  "mcpServers": {
+    "bear-notes": {
+      "command": "npx",
+      "args": ["-y", "bear-notes-mcp@latest"],
+      "env": {
+        "UI_ENABLE_URL_GRAB": "true"
+      }
+    }
+  }
+}
+```
+
 ## Technical Details
 
 This server reads your Bear Notes SQLite database directly for search/read operations and uses Bear's X-callback-URL API for write operations. All data processing happens locally on your machine with no external network calls.

--- a/manifest.json
+++ b/manifest.json
@@ -30,7 +30,9 @@
       "env": {
         "UI_DEBUG_TOGGLE": "${user_config.debug}",
         "UI_ENABLE_NEW_NOTE_CONVENTION": "${user_config.enable_new_note_convention}",
-        "UI_ENABLE_CONTENT_REPLACEMENT": "${user_config.enable_content_replacement}"
+        "UI_ENABLE_CONTENT_REPLACEMENT": "${user_config.enable_content_replacement}",
+        "UI_ENABLE_FILE_ATTACHMENT": "${user_config.enable_file_attachment}",
+        "UI_ENABLE_URL_GRAB": "${user_config.enable_url_grab}"
       }
     }
   },
@@ -53,6 +55,20 @@
       "type": "boolean",
       "title": "Content Replacement",
       "description": "Allow replacing note content or specific sections using the bear-replace-text tool",
+      "default": false,
+      "required": false
+    },
+    "enable_file_attachment": {
+      "type": "boolean",
+      "title": "File Attachment",
+      "description": "Allow attaching files from disk to Bear notes using the bear-add-file tool. When enabled, the AI can read any file path it is given and attach it to a note.",
+      "default": false,
+      "required": false
+    },
+    "enable_url_grab": {
+      "type": "boolean",
+      "title": "URL Grabbing",
+      "description": "Allow saving web pages as Bear notes using the bear-grab-url tool. When enabled, the AI can cause your machine to fetch arbitrary URLs via Bear.",
       "default": false,
       "required": false
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,8 @@ export const BEAR_DATABASE_PATH =
 
 export const ENABLE_NEW_NOTE_CONVENTIONS = process.env.UI_ENABLE_NEW_NOTE_CONVENTION === 'true';
 export const ENABLE_CONTENT_REPLACEMENT = process.env.UI_ENABLE_CONTENT_REPLACEMENT === 'true';
+export const ENABLE_FILE_ATTACHMENT = process.env.UI_ENABLE_FILE_ATTACHMENT === 'true';
+export const ENABLE_URL_GRAB = process.env.UI_ENABLE_URL_GRAB === 'true';
 
 export const ERROR_MESSAGES = {
   BEAR_DATABASE_NOT_FOUND:

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 
-import { APP_VERSION, ENABLE_CONTENT_REPLACEMENT, ENABLE_NEW_NOTE_CONVENTIONS } from './config.js';
+import { APP_VERSION, ENABLE_CONTENT_REPLACEMENT, ENABLE_FILE_ATTACHMENT, ENABLE_NEW_NOTE_CONVENTIONS, ENABLE_URL_GRAB } from './config.js';
 import { applyNoteConventions } from './note-conventions.js';
 import {
   cleanBase64,
@@ -462,7 +462,7 @@ Remove the header parameter to replace the full note body, or change scope to "s
   }
 );
 
-server.registerTool(
+if (ENABLE_FILE_ATTACHMENT) server.registerTool(
   'bear-add-file',
   {
     title: 'Add File to Note',
@@ -511,6 +511,12 @@ server.registerTool(
     logger.info(
       `bear-add-file called with file_path: ${file_path || 'none'}, base64_content: ${base64_content ? 'provided' : 'none'}, filename: ${filename || 'none'}, id: ${id || 'none'}, title: ${title || 'none'}`
     );
+
+    if (!ENABLE_FILE_ATTACHMENT) {
+      return createErrorResponse(`File attachment is not enabled. Do not retry — this requires a settings change by the user.
+
+To use this tool, the user must enable "File Attachment" in the Bear Notes server settings.`);
+    }
 
     if (!id && !title) {
       return createErrorResponse(
@@ -939,7 +945,7 @@ The tag has been removed from all notes. The notes themselves are not affected.`
   }
 );
 
-server.registerTool(
+if (ENABLE_URL_GRAB) server.registerTool(
   'bear-grab-url',
   {
     title: 'Grab URL as Note',
@@ -967,6 +973,12 @@ server.registerTool(
   },
   async ({ url, tags }): Promise<CallToolResult> => {
     logger.info(`bear-grab-url called with url: "${url}", tags: ${tags || 'none'}`);
+
+    if (!ENABLE_URL_GRAB) {
+      return createErrorResponse(`URL grabbing is not enabled. Do not retry — this requires a settings change by the user.
+
+To use this tool, the user must enable "URL Grabbing" in the Bear Notes server settings.`);
+    }
 
     try {
       const bearUrl = buildBearUrl('grab-url', {


### PR DESCRIPTION
## What changed

`bear-add-file` and `bear-grab-url` are now disabled by default and must be explicitly opted into via user config.

**`bear-add-file`** accepts a file path from the LLM and reads it from disk with no path restrictions — a prompt-injected note or fetched webpage could chain into reading sensitive files (e.g. `~/.ssh/id_rsa`) and attaching them to a note.

**`bear-grab-url`** passes arbitrary URLs to Bear for fetching, which can cause outbound requests to local network targets.

## Implementation

Each tool now has two layers of protection:

1. **Conditional registration** — the tool is not listed at all unless the flag is enabled (`if (ENABLE_*) server.registerTool(...)`), so it is invisible to the LLM by default.
2. **Runtime guard** — defence-in-depth check inside the handler, matching the existing pattern used by `bear-replace-text`.

New opt-in toggles (both default `false`):

| env var | user_config key | title |
|---|---|---|
| `UI_ENABLE_FILE_ATTACHMENT` | `enable_file_attachment` | File Attachment |
| `UI_ENABLE_URL_GRAB` | `enable_url_grab` | URL Grabbing |

README updated with a `[!WARNING]` callout for each toggle explaining the specific risk before users enable it.