### PR TITLE
docs: add security posture document

### DIFF
--- a/docs/dev/SECURITY.md
+++ b/docs/dev/SECURITY.md
@@ -2,7 +2,9 @@
 
 ## What This Document Is For
 
-Bear Notes MCP is a small open-source tool distributed via npm and MCPB to a real, if modest, user base. Security decisions here shape everyday UX for those users, which means they need to live somewhere other than chat logs and maintainer memory. This doc is the reference for evaluating security-flavored PRs and issues: what this project defends against, what it doesn't, and the principles that settle the question when a new PR appears.
+Bear Notes MCP is a small open-source tool distributed via npm and MCPB to a real, if modest, user base. Security decisions here shape everyday UX for those users, which means they need to live somewhere other than chat logs and maintainer memory.
+
+This doc is the reference for anyone working on the project — the maintainer, AI collaborators, outside contributors — when validating an idea, reviewing an implementation, or deciding whether a new capability belongs here. It states what this project defends against, what it doesn't, and the principles that settle the question when a new proposal is on the table.
 
 Not a compliance document.
 

--- a/docs/dev/SECURITY.md
+++ b/docs/dev/SECURITY.md
@@ -48,7 +48,7 @@ Content already inside the user's Bear library is not treated as a threat vector
 1. A fully compromised LLM or client. If the client is malicious or the LLM is jailbroken into adversarial behavior, this server is not the last line of defense.
 2. Local attackers already on the user's machine. They have broader primitives than this server exposes.
 3. Bear app vulnerabilities. Bugs in Bear's x-callback-url handling or its database schema are upstream.
-4. Supply-chain compromise of dependencies. We rely on Snyk for known CVEs.
+4. Supply-chain compromise of dependencies.
 5. Content the user themselves wrote into Bear being exposed to the LLM. That is the intended function of the server.
 
 ---
@@ -59,12 +59,12 @@ Standing rules. These are how new code is expected to be written and how existin
 
 | Class | Rule |
 |-------|------|
-| Database reads | Every query goes through `db.prepare(...)` with bound parameters. String interpolation of user or LLM input into SQL is forbidden. `LIKE` queries escape `%`, `_`, `\` before binding. The connection is opened read-only. |
+| Database reads | Every query goes through `db.prepare(...)` with bound parameters. String interpolation of user or LLM input into SQL is forbidden. `LIKE` queries escape `%`, `_`, `\` before binding when those characters are meant to be treated literally. The connection is opened read-only. |
 | Subprocess | Every invocation uses `spawn()` (or equivalent) with an argv array. Shell-string concatenation is forbidden. |
 | URL construction | URLs are built with `URLSearchParams`, not string concatenation. The `bear://` scheme is a constant, not input. |
-| Tool inputs | Tool inputs use zod schemas with a `.trim().min(1)` baseline on strings, enum restriction where values are bounded, scheme restriction for URL inputs, and integer bounds on numeric limits. |
+| Tool inputs | Tool inputs use zod schemas: required strings use a `.trim().min(1)` baseline; optional strings use `.trim()` with explicit handling of empty values. Enum restriction where values are bounded, scheme restriction for URL inputs, integer bounds on numeric limits. |
 | Destructive writes | Operations that overwrite user content are gated behind an opt-in env var (the `ENABLE_CONTENT_REPLACEMENT` pattern). No tool permanently deletes user data — archive is the substitute. |
-| Surface-expanding tools | Tools that grant the Node process a capability the MCP client does not already provide (file read, network fetch) narrow what the LLM can reach: path policy and size cap for filesystem, host filter for network. |
+| Surface-expanding tools | New tools that grant the Node process a capability the MCP client does not already provide (file read, network fetch) must narrow what the LLM can reach: path policy and size cap for filesystem, host filter for network. |
 
 ---
 
@@ -74,7 +74,7 @@ These sit underneath the project's general KISS / YAGNI principles.
 
 1. **Prefer input validation over feature flags.** A feature flag hides a tool; validation narrows it. Validation preserves UX and is the right default unless the capability is genuinely irrecoverable when misused.
 
-2. **Safety gates are for irreversibility plus regret.** `ENABLE_CONTENT_REPLACEMENT` exists because overwriting a note with the wrong content is hard to undo and the user would be unhappy. A gate for a tool whose worst case is "a note got created with an unexpected file attached" is overkill — the user can archive it.
+2. **Safety gates are for irreversibility plus regret.** `ENABLE_CONTENT_REPLACEMENT` exists because overwriting a note with the wrong content is hard to undo and the user would be unhappy. A gate for a tool whose worst case is recoverable inside Bear — an unwanted note created, a tag applied wrong — is overkill; the user can undo it. Note that Bear-side reversibility is not the same as capability-level reversibility: a tool that reads arbitrary files or fetches arbitrary hosts may still need narrowing even if its Bear-side output is archivable, because the confidentiality or network side-effect already happened.
 
 3. **Do not ship defense-in-depth as dead code.** If a guard is unreachable (for example, a runtime check inside a handler that cannot be invoked because its registration was skipped), pick one layer. Unreachable branches are not defense; they are future confusion.
 

--- a/docs/dev/SECURITY.md
+++ b/docs/dev/SECURITY.md
@@ -80,4 +80,4 @@ These sit underneath the project's general KISS / YAGNI principles.
 
 4. **Any new tool that grants the Node process a capability the MCP client does not already provide requires a threat-model note in the PR.** `bear-add-file` grants arbitrary disk read; `bear-grab-url` grants arbitrary HTTP fetch. These are the capabilities that need narrowing. A tool that only reads Bear's own database or writes via `x-callback-url` does not expand the client's surface and does not need a special note.
 
-5. **Honesty over theater.** An opt-in flag that the user will always flip on is not a defense — it is a UX tax disguised as one. If a mitigation does not actually reduce risk for the realistic user, do not ship it.
+5. **Honesty over theater.** A gate defends only when enabling it is a real risk-acceptance — the user is actively deciding to live with a specific failure mode. A gate that every realistic user flips on reflexively ("I just wanted the tool") is UX tax, not defense. This is why gates sit on irreversible operations, where enabling asks a real question, rather than on recoverable ones, where there is nothing to accept.

--- a/docs/dev/SECURITY.md
+++ b/docs/dev/SECURITY.md
@@ -14,7 +14,7 @@ Not a compliance document.
 
 Bear Notes MCP is a single-user desktop server. It runs locally on macOS, reads the user's Bear SQLite database, and writes to Bear via `x-callback-url`. It is invoked by an MCP client (Claude Desktop, Claude Code, Cursor, etc.) under the same UID as the user.
 
-The operator and the beneficiary are the same person. There is no multi-tenancy, no remote surface, no authentication layer — the OS user account is the trust boundary.
+The operator and the beneficiary are the same person. There is no multi-tenancy, no inbound remote surface, no authentication layer — the OS user account is the trust boundary. (Outbound network access happens via Bear when the user invokes a URL-grabbing tool.)
 
 ---
 
@@ -62,7 +62,7 @@ Standing rules. These are how new code is expected to be written and how existin
 | Database reads | Every query goes through `db.prepare(...)` with bound parameters. String interpolation of user or LLM input into SQL is forbidden. `LIKE` queries escape `%`, `_`, `\` before binding when those characters are meant to be treated literally. The connection is opened read-only. |
 | Subprocess | Every invocation uses `spawn()` (or equivalent) with an argv array. Shell-string concatenation is forbidden. |
 | URL construction | URLs are built with `URLSearchParams`, not string concatenation. The `bear://` scheme is a constant, not input. |
-| Tool inputs | Tool inputs use zod schemas: required strings use a `.trim().min(1)` baseline; optional strings use `.trim()` with explicit handling of empty values. Enum restriction where values are bounded, scheme restriction for URL inputs, integer bounds on numeric limits. |
+| Tool inputs | Tool inputs use zod schemas: required strings use a `.trim().min(1)` baseline; optional strings use `.trim()` with explicit handling of empty values. Use enum restriction where values are bounded and scheme restriction for URL inputs. |
 | Destructive writes | Operations that overwrite user content are gated behind an opt-in env var (the `ENABLE_CONTENT_REPLACEMENT` pattern). No tool permanently deletes user data — archive is the substitute. |
 | Surface-expanding tools | New tools that grant the Node process a capability the MCP client does not already provide (file read, network fetch) must narrow what the LLM can reach: path policy and size cap for filesystem, host filter for network. |
 
@@ -72,9 +72,9 @@ Standing rules. These are how new code is expected to be written and how existin
 
 These sit underneath the project's general KISS / YAGNI principles.
 
-1. **Prefer input validation over feature flags.** A feature flag hides a tool; validation narrows it. Validation preserves UX and is the right default unless the capability is genuinely irrecoverable when misused.
+1. **Prefer input validation over feature flags.** A feature flag hides a tool; validation narrows it. Validation preserves UX and is the right default unless the capability is genuinely irreversible when misused.
 
-2. **Safety gates are for irreversibility plus regret.** `ENABLE_CONTENT_REPLACEMENT` exists because overwriting a note with the wrong content is hard to undo and the user would be unhappy. A gate for a tool whose worst case is recoverable inside Bear — an unwanted note created, a tag applied wrong — is overkill; the user can undo it. Note that Bear-side reversibility is not the same as capability-level reversibility: a tool that reads arbitrary files or fetches arbitrary hosts may still need narrowing even if its Bear-side output is archivable, because the confidentiality or network side-effect already happened.
+2. **Safety gates are for irreversibility plus regret.** `ENABLE_CONTENT_REPLACEMENT` exists because overwriting a note with the wrong content is hard to undo and the user would be unhappy. A gate for a tool whose worst case is reversible inside Bear — an unwanted note created, a tag applied wrong — is overkill; the user can undo it. Note that Bear-side reversibility is not the same as capability-level reversibility: a tool that reads arbitrary files or fetches arbitrary hosts may still need narrowing even if its Bear-side output is reversible, because the confidentiality or network side-effect already happened.
 
 3. **Do not ship defense-in-depth as dead code.** If a guard is unreachable (for example, a runtime check inside a handler that cannot be invoked because its registration was skipped), pick one layer. Unreachable branches are not defense; they are future confusion.
 

--- a/docs/dev/SECURITY.md
+++ b/docs/dev/SECURITY.md
@@ -1,0 +1,113 @@
+# Security Posture
+
+## What This Document Is For
+
+This is a hobby project with one user (the author) and a small number of other users who install it from npm or as an MCPB bundle. This doc exists so that security decisions — what we defend against, what we don't, and why — are a lookup rather than a memory exercise. It is the reference for evaluating security-flavored PRs and issues.
+
+Not a compliance document. Not a responsible-disclosure SLA. Just a written position.
+
+---
+
+## Context
+
+Bear Notes MCP is a single-user desktop server. It runs locally on macOS, reads the user's Bear SQLite database, and writes to Bear via `x-callback-url`. It is invoked by an MCP client (Claude Desktop, Claude Code, Cursor, etc.) under the same UID as the user.
+
+The operator and the beneficiary are the same person. There is no multi-tenancy, no remote surface, no authentication layer — the OS user account is the trust boundary.
+
+---
+
+## Trust Model
+
+| Component | Trust level | Notes |
+|-----------|-------------|-------|
+| User | Fully trusted | Operator of the machine and target of all output |
+| Operating system (macOS) | Trusted | We rely on Gatekeeper, filesystem permissions, and the UID boundary |
+| Bear app | Trusted | The user chose to install it; we do not defend against Bear bugs |
+| MCP client (Claude Desktop, Claude Code, etc.) | Trusted to be the user's chosen client | We do not defend against a malicious client |
+| LLM behind the MCP client | **Partially trusted** | Treated as a fallible collaborator — may make mistakes, may be influenced by prompt injection inside content it reads. Not treated as fully hostile. |
+| Content the LLM reads (Bear notes, fetched URLs) | Untrusted | Anything a user pastes into a note or a fetched web page may contain injection attempts |
+| Filesystem paths chosen by the LLM | Untrusted choice, trusted contents | The file contents belong to the user, but the *choice of which file* comes from the LLM and should be narrowed |
+| Network destinations chosen by the LLM | Untrusted | Same reasoning as above |
+
+The key asymmetry: the LLM is trusted enough to be given tools, but not trusted enough to freely pick arbitrary file paths or arbitrary hosts. This is the axis most server-side defenses sit on.
+
+---
+
+## What We Defend Against
+
+1. **Accidental data loss in the user's notes** — covered by the `bear-replace-text` opt-in gate and the absence of a delete tool (see `SPECIFICATION.md` § Safety Gates).
+2. **SQL injection via user input** — covered by parameterized queries and a read-only database connection.
+3. **Shell injection via the subprocess path** — covered by `spawn()` with an argv array; no shell interpolation.
+4. **LLM misjudgment of dangerous primitives** — this is the work that is *partially done*. Tools that grant file-read or network-fetch primitives should narrow what the LLM can reach, even when the user is not actively paying attention.
+
+## What We Do Not Defend Against
+
+1. **A fully compromised LLM or client.** If the client is malicious or the LLM is jailbroken into adversarial behavior, this server is not the last line of defense — the client already has direct filesystem and network access in most MCP setups.
+2. **Local attackers already on the user's machine.** They have broader primitives than this server exposes.
+3. **Bear app vulnerabilities.** Bugs in Bear's x-callback-url handling or its database schema are upstream.
+4. **Supply-chain compromise of npm dependencies.** We use Snyk for known CVEs but do not vendor or audit transitive deps.
+5. **Content the user themselves wrote into Bear being exposed to the LLM.** That is the intended function of the server.
+
+---
+
+## Current Protections
+
+Inventory as of 2026-04. Update this table when adding or removing a protection.
+
+| Layer | Protection | Where |
+|-------|------------|-------|
+| SQL | Parameterized queries, read-only DB, LIKE wildcard escaping | `database.ts`, `notes.ts`, `tags.ts` |
+| Subprocess | `spawn()` with argv array, no shell | `bear-urls.ts` |
+| URL construction | `URLSearchParams` + `%20` post-pass, fixed `bear://` scheme | `bear-urls.ts`, `config.ts` |
+| Tool input | Zod schemas with `.trim().min(1)` baseline, enum-restricted fields where applicable | `main.ts` |
+| Destructive writes | `ENABLE_CONTENT_REPLACEMENT` opt-in gate on `bear-replace-text` | `main.ts`, `config.ts` |
+| Delete operations | No tool exists. Archive only. | by omission |
+| `bear-grab-url` | `http`/`https` scheme enforcement | `main.ts` |
+| `bear-add-file` | Handled `ENOENT` / `EACCES` / empty-file errors | `main.ts` |
+
+---
+
+## Known Gaps
+
+These are acknowledged and, where applicable, tracked as issues. Presence in this list is not a commitment to fix — it's honesty about the current state.
+
+| Gap | Risk | Current stance |
+|-----|------|----------------|
+| `bear-add-file` accepts any path the Node process can read (no traversal check, no symlink resolution, no allowlist, no size cap, no MIME check) | LLM could be nudged by prompt injection into reading `~/.ssh/id_rsa` or similar | Planned: path policy + size cap. Preference is input validation over feature-flag gating. |
+| `bear-grab-url` has no host filter (no block on `localhost`, RFC1918, link-local, metadata endpoints) | Fetch handoff is Bear's, but the server does not narrow the surface | Planned: host filter with opt-in escape hatch for private networks |
+| No audit log of writes | User cannot reconstruct what the LLM did | Accepted. Logs go to stderr via `debug`; the user's Bear version history is the audit trail for content. |
+| No rate limiting or tool-call throttling | An LLM loop could spam Bear with writes | Accepted. Low risk at hobby scale; would complicate UX. |
+| No interactive confirmation for destructive operations | Reliance on opt-in flags and Bear's archive-over-delete model | Accepted. Confirmation prompts belong in the MCP client, not here. |
+| `limit` parameters on search tools lack `.int().min().max()` bounds | Minor DoS via huge result sets | Low priority, cheap to fix when next touching the file. |
+
+---
+
+## Principles for Security Decisions
+
+These are the rules of thumb used to evaluate security-flavored PRs and issues. They sit underneath the project's general KISS / YAGNI principles.
+
+1. **Prefer input validation over feature flags.** A feature flag hides a tool; validation narrows it. Validation preserves UX and is the right default unless the capability is genuinely irrecoverable when misused.
+
+2. **Safety gates are for irreversibility plus regret.** `ENABLE_CONTENT_REPLACEMENT` exists because overwriting a note with the wrong content is hard to undo and the user would be unhappy. A gate for a tool whose worst case is "a note got created with an unexpected file attached" is overkill — the user can archive it.
+
+3. **Do not ship defense-in-depth as dead code.** If a guard is unreachable (for example, a runtime check inside a handler that cannot be invoked because its registration was skipped), pick one layer. Unreachable branches are not defense; they are future confusion.
+
+4. **Any new tool that grants the Node process a capability the MCP client does not already provide requires a threat-model note in the PR.** `bear-add-file` grants arbitrary disk read; `bear-grab-url` grants arbitrary HTTP fetch. These are the capabilities that need narrowing. A tool that only reads Bear's own database or writes via `x-callback-url` does not expand the client's surface and does not need a special note.
+
+5. **Update this document when a security decision is made.** Add to the protections table when a defense lands. Add to the gaps table when a gap is identified. Move items between them as they change. If a decision overrides one of the principles above, say so here rather than in a PR comment that will be forgotten.
+
+6. **Honesty over theater.** An opt-in flag that the user will always flip on is not a defense — it is a UX tax disguised as one. If a mitigation does not actually reduce risk for the realistic user, do not ship it.
+
+---
+
+## Reporting
+
+This is a personal project. If you find something you believe is a security issue, open a GitHub issue or contact the maintainer via the email listed in `package.json`. Response time is best-effort. There is no embargo process and no bounty.
+
+---
+
+## References
+
+- `SPECIFICATION.md` — system architecture, safety gates, error handling contract
+- `BEAR_DATABASE_SCHEMA.md` — database structure and fragility points
+- MCP specification: https://spec.modelcontextprotocol.io/

--- a/docs/dev/SECURITY.md
+++ b/docs/dev/SECURITY.md
@@ -2,9 +2,9 @@
 
 ## What This Document Is For
 
-This is a hobby project with one user (the author) and a small number of other users who install it from npm or as an MCPB bundle. This doc exists so that security decisions — what we defend against, what we don't, and why — are a lookup rather than a memory exercise. It is the reference for evaluating security-flavored PRs and issues.
+Bear Notes MCP is a small open-source tool distributed via npm and MCPB to a real, if modest, user base. Security decisions here shape everyday UX for those users, which means they need to live somewhere other than chat logs and maintainer memory. This doc is the reference for evaluating security-flavored PRs and issues: what this project defends against, what it doesn't, and the principles that settle the question when a new PR appears.
 
-Not a compliance document. Not a responsible-disclosure SLA. Just a written position.
+Not a compliance document.
 
 ---
 
@@ -23,36 +23,35 @@ The operator and the beneficiary are the same person. There is no multi-tenancy,
 | User | Fully trusted | Operator of the machine and target of all output |
 | Operating system (macOS) | Trusted | We rely on Gatekeeper, filesystem permissions, and the UID boundary |
 | Bear app | Trusted | The user chose to install it; we do not defend against Bear bugs |
-| MCP client (Claude Desktop, Claude Code, etc.) | Trusted to be the user's chosen client | We do not defend against a malicious client |
-| LLM behind the MCP client | **Partially trusted** | Treated as a fallible collaborator — may make mistakes, may be influenced by prompt injection inside content it reads. Not treated as fully hostile. |
-| Content the LLM reads (Bear notes, fetched URLs) | Untrusted | Anything a user pastes into a note or a fetched web page may contain injection attempts |
-| Filesystem paths chosen by the LLM | Untrusted choice, trusted contents | The file contents belong to the user, but the *choice of which file* comes from the LLM and should be narrowed |
-| Network destinations chosen by the LLM | Untrusted | Same reasoning as above |
+| MCP client | Trusted to be the user's chosen client | We do not defend against a malicious client |
+| LLM behind the MCP client | **Partially trusted** | A fallible collaborator — may make mistakes, may be influenced by prompt injection inside content it fetches. Not treated as fully hostile. |
+| Content fetched from the network | Untrusted | A fetched web page may contain text intended to manipulate the LLM into unintended tool calls |
+| Filesystem paths and hosts chosen by the LLM | Untrusted choice | The user's files and their network belong to them, but the *choice of which file or host* comes from the LLM and should be narrowed |
 
 The key asymmetry: the LLM is trusted enough to be given tools, but not trusted enough to freely pick arbitrary file paths or arbitrary hosts. This is the axis most server-side defenses sit on.
+
+Content already inside the user's Bear library is not treated as a threat vector. If the user put something in a note, they accepted that risk. Server-side defenses narrow what an LLM nudged by *incoming* content (a fetched page, an attached file) can do — not what the user stored themselves.
 
 ---
 
 ## What We Defend Against
 
 1. **Accidental data loss in the user's notes** — covered by the `bear-replace-text` opt-in gate and the absence of a delete tool (see `SPECIFICATION.md` § Safety Gates).
-2. **SQL injection via user input** — covered by parameterized queries and a read-only database connection.
+2. **SQL injection via user or LLM input** — covered by parameterized queries and a read-only database connection.
 3. **Shell injection via the subprocess path** — covered by `spawn()` with an argv array; no shell interpolation.
-4. **LLM misjudgment of dangerous primitives** — this is the work that is *partially done*. Tools that grant file-read or network-fetch primitives should narrow what the LLM can reach, even when the user is not actively paying attention.
+4. **LLM overreach on tools that expose new primitives** — tools that grant file-read or network-fetch capabilities narrow what the LLM can reach. These are the capabilities that expand the server's surface beyond what the MCP client already provides.
 
 ## What We Do Not Defend Against
 
-1. **A fully compromised LLM or client.** If the client is malicious or the LLM is jailbroken into adversarial behavior, this server is not the last line of defense — the client already has direct filesystem and network access in most MCP setups.
-2. **Local attackers already on the user's machine.** They have broader primitives than this server exposes.
-3. **Bear app vulnerabilities.** Bugs in Bear's x-callback-url handling or its database schema are upstream.
-4. **Supply-chain compromise of npm dependencies.** We use Snyk for known CVEs but do not vendor or audit transitive deps.
-5. **Content the user themselves wrote into Bear being exposed to the LLM.** That is the intended function of the server.
+1. A fully compromised LLM or client. If the client is malicious or the LLM is jailbroken into adversarial behavior, this server is not the last line of defense.
+2. Local attackers already on the user's machine. They have broader primitives than this server exposes.
+3. Bear app vulnerabilities. Bugs in Bear's x-callback-url handling or its database schema are upstream.
+4. Supply-chain compromise of dependencies. We rely on Snyk for known CVEs.
+5. Content the user themselves wrote into Bear being exposed to the LLM. That is the intended function of the server.
 
 ---
 
 ## Current Protections
-
-Inventory as of 2026-04. Update this table when adding or removing a protection.
 
 | Layer | Protection | Where |
 |-------|------------|-------|
@@ -63,28 +62,12 @@ Inventory as of 2026-04. Update this table when adding or removing a protection.
 | Destructive writes | `ENABLE_CONTENT_REPLACEMENT` opt-in gate on `bear-replace-text` | `main.ts`, `config.ts` |
 | Delete operations | No tool exists. Archive only. | by omission |
 | `bear-grab-url` | `http`/`https` scheme enforcement | `main.ts` |
-| `bear-add-file` | Handled `ENOENT` / `EACCES` / empty-file errors | `main.ts` |
-
----
-
-## Known Gaps
-
-These are acknowledged and, where applicable, tracked as issues. Presence in this list is not a commitment to fix — it's honesty about the current state.
-
-| Gap | Risk | Current stance |
-|-----|------|----------------|
-| `bear-add-file` accepts any path the Node process can read (no traversal check, no symlink resolution, no allowlist, no size cap, no MIME check) | LLM could be nudged by prompt injection into reading `~/.ssh/id_rsa` or similar | Planned: path policy + size cap. Preference is input validation over feature-flag gating. |
-| `bear-grab-url` has no host filter (no block on `localhost`, RFC1918, link-local, metadata endpoints) | Fetch handoff is Bear's, but the server does not narrow the surface | Planned: host filter with opt-in escape hatch for private networks |
-| No audit log of writes | User cannot reconstruct what the LLM did | Accepted. Logs go to stderr via `debug`; the user's Bear version history is the audit trail for content. |
-| No rate limiting or tool-call throttling | An LLM loop could spam Bear with writes | Accepted. Low risk at hobby scale; would complicate UX. |
-| No interactive confirmation for destructive operations | Reliance on opt-in flags and Bear's archive-over-delete model | Accepted. Confirmation prompts belong in the MCP client, not here. |
-| `limit` parameters on search tools lack `.int().min().max()` bounds | Minor DoS via huge result sets | Low priority, cheap to fix when next touching the file. |
 
 ---
 
 ## Principles for Security Decisions
 
-These are the rules of thumb used to evaluate security-flavored PRs and issues. They sit underneath the project's general KISS / YAGNI principles.
+These sit underneath the project's general KISS / YAGNI principles.
 
 1. **Prefer input validation over feature flags.** A feature flag hides a tool; validation narrows it. Validation preserves UX and is the right default unless the capability is genuinely irrecoverable when misused.
 
@@ -94,20 +77,4 @@ These are the rules of thumb used to evaluate security-flavored PRs and issues. 
 
 4. **Any new tool that grants the Node process a capability the MCP client does not already provide requires a threat-model note in the PR.** `bear-add-file` grants arbitrary disk read; `bear-grab-url` grants arbitrary HTTP fetch. These are the capabilities that need narrowing. A tool that only reads Bear's own database or writes via `x-callback-url` does not expand the client's surface and does not need a special note.
 
-5. **Update this document when a security decision is made.** Add to the protections table when a defense lands. Add to the gaps table when a gap is identified. Move items between them as they change. If a decision overrides one of the principles above, say so here rather than in a PR comment that will be forgotten.
-
-6. **Honesty over theater.** An opt-in flag that the user will always flip on is not a defense — it is a UX tax disguised as one. If a mitigation does not actually reduce risk for the realistic user, do not ship it.
-
----
-
-## Reporting
-
-This is a personal project. If you find something you believe is a security issue, open a GitHub issue or contact the maintainer via the email listed in `package.json`. Response time is best-effort. There is no embargo process and no bounty.
-
----
-
-## References
-
-- `SPECIFICATION.md` — system architecture, safety gates, error handling contract
-- `BEAR_DATABASE_SCHEMA.md` — database structure and fragility points
-- MCP specification: https://spec.modelcontextprotocol.io/
+5. **Honesty over theater.** An opt-in flag that the user will always flip on is not a defense — it is a UX tax disguised as one. If a mitigation does not actually reduce risk for the realistic user, do not ship it.

--- a/docs/dev/SECURITY.md
+++ b/docs/dev/SECURITY.md
@@ -38,10 +38,10 @@ Content already inside the user's Bear library is not treated as a threat vector
 
 ## What We Defend Against
 
-1. **Accidental data loss in the user's notes** — covered by the `bear-replace-text` opt-in gate and the absence of a delete tool (see `SPECIFICATION.md` § Safety Gates).
-2. **SQL injection via user or LLM input** — covered by parameterized queries and a read-only database connection.
-3. **Shell injection via the subprocess path** — covered by `spawn()` with an argv array; no shell interpolation.
-4. **LLM overreach on tools that expose new primitives** — tools that grant file-read or network-fetch capabilities narrow what the LLM can reach. These are the capabilities that expand the server's surface beyond what the MCP client already provides.
+1. Accidental data loss in the user's notes.
+2. SQL injection via user or LLM input.
+3. Shell injection via the subprocess path.
+4. LLM overreach on tools that expose primitives beyond what the MCP client already provides (file read, network fetch).
 
 ## What We Do Not Defend Against
 
@@ -53,17 +53,18 @@ Content already inside the user's Bear library is not treated as a threat vector
 
 ---
 
-## Current Protections
+## How We Defend
 
-| Layer | Protection | Where |
-|-------|------------|-------|
-| SQL | Parameterized queries, read-only DB, LIKE wildcard escaping | `database.ts`, `notes.ts`, `tags.ts` |
-| Subprocess | `spawn()` with argv array, no shell | `bear-urls.ts` |
-| URL construction | `URLSearchParams` + `%20` post-pass, fixed `bear://` scheme | `bear-urls.ts`, `config.ts` |
-| Tool input | Zod schemas with `.trim().min(1)` baseline, enum-restricted fields where applicable | `main.ts` |
-| Destructive writes | `ENABLE_CONTENT_REPLACEMENT` opt-in gate on `bear-replace-text` | `main.ts`, `config.ts` |
-| Delete operations | No tool exists. Archive only. | by omission |
-| `bear-grab-url` | `http`/`https` scheme enforcement | `main.ts` |
+Standing rules. These are how new code is expected to be written and how existing code is already structured. A PR that cannot follow one of these should explain why in its description.
+
+| Class | Rule |
+|-------|------|
+| Database reads | Every query goes through `db.prepare(...)` with bound parameters. String interpolation of user or LLM input into SQL is forbidden. `LIKE` queries escape `%`, `_`, `\` before binding. The connection is opened read-only. |
+| Subprocess | Every invocation uses `spawn()` (or equivalent) with an argv array. Shell-string concatenation is forbidden. |
+| URL construction | URLs are built with `URLSearchParams`, not string concatenation. The `bear://` scheme is a constant, not input. |
+| Tool inputs | Tool inputs use zod schemas with a `.trim().min(1)` baseline on strings, enum restriction where values are bounded, scheme restriction for URL inputs, and integer bounds on numeric limits. |
+| Destructive writes | Operations that overwrite user content are gated behind an opt-in env var (the `ENABLE_CONTENT_REPLACEMENT` pattern). No tool permanently deletes user data — archive is the substitute. |
+| Surface-expanding tools | Tools that grant the Node process a capability the MCP client does not already provide (file read, network fetch) narrow what the LLM can reach: path policy and size cap for filesystem, host filter for network. |
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `docs/dev/SECURITY.md`, a companion to `SPECIFICATION.md` that records the project's security posture.
- Defines the trust model: who is trusted, who isn't, and the key asymmetry that the LLM is trusted enough to hold tools but not trusted enough to freely pick arbitrary file paths or hosts.
- States explicitly what this project defends against (accidental data loss, SQL/shell injection, LLM overreach on surface-expanding tools) and what it deliberately does not (compromised client, local attackers, Bear bugs, supply chain, content the user wrote into their own library).
- Captures how defenses are implemented today as standing rules — parameterized SQL, argv-array subprocess, `URLSearchParams`-built URLs, zod-validated tool inputs, opt-in gates for irreversible writes, narrowing for tools that expand the Node process's capability beyond the MCP client.
- Records the principles for evaluating future security-flavored proposals: prefer validation over feature flags, reserve safety gates for irreversibility plus regret, do not ship defense-in-depth as dead code, require a threat-model note for any tool that grants a new capability, and honesty over theater.

## Why
The project had no written security position. The trigger for writing one was #106 by @UnicornaasTech, which raised a legitimate concern about `bear-add-file` and `bear-grab-url` being under-validated. The discussion around that PR made it clear the project needed a reference that states what it defends against, what it doesn't, and on what basis future proposals should be evaluated — so those questions have a shared starting point rather than being re-litigated case by case. Thanks to @UnicornaasTech for raising the question that made this doc necessary.
