### PR TITLE
ci: build .mcpb bundle on every PR

### DIFF
--- a/.github/workflows/build-bundle-pr.yml
+++ b/.github/workflows/build-bundle-pr.yml
@@ -46,18 +46,11 @@ jobs:
           echo "build_version=${BV}" >> "$GITHUB_OUTPUT"
           echo "Build version: ${BV}"
 
-      # Stamp the computed version into the three files task version keeps in
-      # sync (Taskfile.yml task: version). Reuses GNU sed for the src/config.ts
-      # single-quoted assignment; uses jq atomic-rename for the JSON files so
-      # formatting and key order are preserved.
+      # Stamp the computed version into manifest.json, package.json, src/config.ts
+      # and regenerate the lockfile. Delegates to `task version` (Taskfile.yml)
+      # so the version-bearing-files list lives in exactly one place.
       - name: Stamp build version
-        run: |
-          set -euo pipefail
-          BV="${{ steps.version.outputs.build_version }}"
-          tmp=$(mktemp) && jq --arg v "$BV" '.version = $v' manifest.json > "$tmp" && mv "$tmp" manifest.json
-          tmp=$(mktemp) && jq --arg v "$BV" '.version = $v' package.json > "$tmp" && mv "$tmp" package.json
-          sed -i "s/export const APP_VERSION = '[^']*'/export const APP_VERSION = '${BV}'/" src/config.ts
-          npm install --package-lock-only
+        run: task version VERSION="${{ steps.version.outputs.build_version }}" -y
 
       - name: Create bundle
         run: task pack

--- a/.github/workflows/build-bundle-pr.yml
+++ b/.github/workflows/build-bundle-pr.yml
@@ -32,22 +32,17 @@ jobs:
         run: npm ci
 
       # Compute a strictly-monotonic build version so Claude Desktop's installer
-      # shows the "Update" affordance for each successive PR push. Scheme:
-      #   <MAJOR>.<MINOR>.<PATCH + run_number>-pr.<PR>
-      # Empirically, Claude Desktop's extension installer compares MAJOR.MINOR.PATCH
-      # and ignores the prerelease segment. Within a PR every push must therefore
-      # produce a higher patch number than the previous push. github.run_number
-      # is workflow-global monotonic, so adding it to the manifest's base patch
-      # yields strictly-increasing patches per push.
+      # always shows the "Update" affordance for each successive PR push. Scheme:
+      #   <base>-pr.<PR>.<run_number>
+      # github.run_number is workflow-global monotonic, so successive pushes to
+      # the same PR are always strictly newer per SemVer's prerelease ordering.
       - name: Compute build version
         id: version
         run: |
           set -euo pipefail
           BASE=$(jq -r .version manifest.json)
           CORE="${BASE%%-*}"
-          IFS=. read -r MAJ MIN PAT <<< "$CORE"
-          NEW_PAT=$((PAT + ${{ github.run_number }}))
-          BV="${MAJ}.${MIN}.${NEW_PAT}-pr.${{ github.event.pull_request.number }}"
+          BV="${CORE}-pr.${{ github.event.pull_request.number }}.${{ github.run_number }}"
           echo "build_version=${BV}" >> "$GITHUB_OUTPUT"
           echo "Build version: ${BV}"
 

--- a/.github/workflows/build-bundle-pr.yml
+++ b/.github/workflows/build-bundle-pr.yml
@@ -32,17 +32,22 @@ jobs:
         run: npm ci
 
       # Compute a strictly-monotonic build version so Claude Desktop's installer
-      # always shows the "Update" affordance for each successive PR push. Scheme:
-      #   <base>-pr.<PR>.<run_number>
-      # github.run_number is workflow-global monotonic, so successive pushes to
-      # the same PR are always strictly newer per SemVer's prerelease ordering.
+      # shows the "Update" affordance for each successive PR push. Scheme:
+      #   <MAJOR>.<MINOR>.<PATCH + run_number>-pr.<PR>
+      # Empirically, Claude Desktop's extension installer compares MAJOR.MINOR.PATCH
+      # and ignores the prerelease segment. Within a PR every push must therefore
+      # produce a higher patch number than the previous push. github.run_number
+      # is workflow-global monotonic, so adding it to the manifest's base patch
+      # yields strictly-increasing patches per push.
       - name: Compute build version
         id: version
         run: |
           set -euo pipefail
           BASE=$(jq -r .version manifest.json)
           CORE="${BASE%%-*}"
-          BV="${CORE}-pr.${{ github.event.pull_request.number }}.${{ github.run_number }}"
+          IFS=. read -r MAJ MIN PAT <<< "$CORE"
+          NEW_PAT=$((PAT + ${{ github.run_number }}))
+          BV="${MAJ}.${MIN}.${NEW_PAT}-pr.${{ github.event.pull_request.number }}"
           echo "build_version=${BV}" >> "$GITHUB_OUTPUT"
           echo "Build version: ${BV}"
 

--- a/.github/workflows/build-bundle-pr.yml
+++ b/.github/workflows/build-bundle-pr.yml
@@ -1,0 +1,78 @@
+name: Build .mcpb bundle for PR
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: build-bundle-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CI: 'true'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Compute a strictly-monotonic build version so Claude Desktop's installer
+      # always shows the "Update" affordance for each successive PR push. Scheme:
+      #   <MAJOR>.<MINOR>.<PATCH+1>-pr.<PR>.<run_number>
+      # Patch-bump (not append) keeps the prerelease strictly greater than the
+      # base released version, so installing a PR build over the released base
+      # is recognized as newer rather than as a downgrade.
+      - name: Compute build version
+        id: version
+        run: |
+          set -euo pipefail
+          BASE=$(jq -r .version manifest.json)
+          CORE="${BASE%%-*}"
+          IFS=. read -r MAJ MIN PAT <<< "$CORE"
+          NEXT_PAT=$((PAT + 1))
+          BV="${MAJ}.${MIN}.${NEXT_PAT}-pr.${{ github.event.pull_request.number }}.${{ github.run_number }}"
+          echo "build_version=${BV}" >> "$GITHUB_OUTPUT"
+          echo "Build version: ${BV}"
+
+      # Stamp the computed version into the three files task version keeps in
+      # sync (Taskfile.yml task: version). Reuses GNU sed for the src/config.ts
+      # single-quoted assignment; uses jq atomic-rename for the JSON files so
+      # formatting and key order are preserved.
+      - name: Stamp build version
+        run: |
+          set -euo pipefail
+          BV="${{ steps.version.outputs.build_version }}"
+          tmp=$(mktemp) && jq --arg v "$BV" '.version = $v' manifest.json > "$tmp" && mv "$tmp" manifest.json
+          tmp=$(mktemp) && jq --arg v "$BV" '.version = $v' package.json > "$tmp" && mv "$tmp" package.json
+          sed -i "s/export const APP_VERSION = '[^']*'/export const APP_VERSION = '${BV}'/" src/config.ts
+          npm install --package-lock-only
+
+      - name: Create bundle
+        run: task pack
+
+      - name: Compute short SHA
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: mcpb-bundle-pr-${{ github.event.pull_request.number }}-${{ steps.vars.outputs.sha_short }}
+          path: bear-notes-mcpb-*.mcpb
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/build-bundle-pr.yml
+++ b/.github/workflows/build-bundle-pr.yml
@@ -33,19 +33,16 @@ jobs:
 
       # Compute a strictly-monotonic build version so Claude Desktop's installer
       # always shows the "Update" affordance for each successive PR push. Scheme:
-      #   <MAJOR>.<MINOR>.<PATCH+1>-pr.<PR>.<run_number>
-      # Patch-bump (not append) keeps the prerelease strictly greater than the
-      # base released version, so installing a PR build over the released base
-      # is recognized as newer rather than as a downgrade.
+      #   <base>-pr.<PR>.<run_number>
+      # github.run_number is workflow-global monotonic, so successive pushes to
+      # the same PR are always strictly newer per SemVer's prerelease ordering.
       - name: Compute build version
         id: version
         run: |
           set -euo pipefail
           BASE=$(jq -r .version manifest.json)
           CORE="${BASE%%-*}"
-          IFS=. read -r MAJ MIN PAT <<< "$CORE"
-          NEXT_PAT=$((PAT + 1))
-          BV="${MAJ}.${MIN}.${NEXT_PAT}-pr.${{ github.event.pull_request.number }}.${{ github.run_number }}"
+          BV="${CORE}-pr.${{ github.event.pull_request.number }}.${{ github.run_number }}"
           echo "build_version=${BV}" >> "$GITHUB_OUTPUT"
           echo "Build version: ${BV}"
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -114,22 +114,22 @@ tasks:
     desc: Update version across all files
     interactive: true
     requires:
-      vars: 
+      vars:
         - VERSION
     prompt: "Confirm version update to {{.VERSION}}?"
     preconditions:
-      - sh: echo "{{.VERSION}}" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$'
-        msg: "VERSION must follow semver format (x.y.z)"
+      - sh: echo "{{.VERSION}}" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'
+        msg: "VERSION must follow semver format (x.y.z[-prerelease])"
     cmds:
       - |
         echo "Updating version to {{.VERSION}}"
-        
-        sed -i '' 's/"version": "[^"]*"/"version": "{{.VERSION}}"/' package.json
-        
-        sed -i '' 's/"version": "[^"]*"/"version": "{{.VERSION}}"/' manifest.json
-        
-        sed -i '' "s/export const APP_VERSION = '[^']*'/export const APP_VERSION = '{{.VERSION}}'/" src/config.ts
-        
+
+        perl -pi -e 's/"version": "[^"]*"/"version": "{{.VERSION}}"/' package.json
+
+        perl -pi -e 's/"version": "[^"]*"/"version": "{{.VERSION}}"/' manifest.json
+
+        perl -pi -e "s/export const APP_VERSION = '[^']*'/export const APP_VERSION = '{{.VERSION}}'/" src/config.ts
+
         echo "Version updated to {{.VERSION}} in package.json, manifest.json, and src/config.ts"
       - npm install --package-lock-only
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// Step 6 failure-path sabotage — to be reverted immediately.
+const _failureProbe: number = 'this is not a number';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,4 @@
 #!/usr/bin/env node
-// Step 6 failure-path sabotage — to be reverted immediately.
-const _failureProbe: number = 'this is not a number';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 


### PR DESCRIPTION
## Summary
- On every PR push to `main`, builds the `.mcpb` bundle and uploads it as a downloadable Actions artifact.
- Bundle is version-stamped with a monotonic prerelease so Claude Desktop's "Update" affordance works for installing each successive PR push over the previous one.
- Stamping delegates to `task version VERSION=... -y` — the workflow doesn't duplicate the list of version-bearing files (`manifest.json`, `package.json`, `src/config.ts`).
- `task version`'s precondition is loosened to accept SemVer prereleases, and its in-place edit switches from BSD `sed -i ''` to `perl -pi -e` so it runs on both macOS and Ubuntu runners.

## Why
Before this, grabbing a bundle from a PR meant checking out the branch and running `task pack` locally, or manually dispatching `build-bundle-from-branch.yml`. This makes it one click from the PR's Actions tab.

The Taskfile edits exist so the workflow can reuse `task version` as the single source of truth for which files carry the version string. Without them the workflow would have had to inline a jq+sed block that drifts the moment someone adds a fourth version-bearing file.

--
