### PR TITLE
ci: post sticky PR comment with .mcpb build link

### DIFF
--- a/.github/workflows/build-bundle-pr.yml
+++ b/.github/workflows/build-bundle-pr.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
     env:
       CI: 'true'
     steps:
@@ -60,9 +61,59 @@ jobs:
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Upload bundle artifact
+        id: upload
         uses: actions/upload-artifact@v7
         with:
           name: mcpb-bundle-pr-${{ github.event.pull_request.number }}-${{ steps.vars.outputs.sha_short }}
           path: bear-notes-mcpb-*.mcpb
           retention-days: 14
           if-no-files-found: error
+
+      # Post (or update on subsequent pushes) a single sticky comment on the PR
+      # so reviewers don't have to dig into the Actions tab to grab the .mcpb.
+      # Identity is anchored by an HTML-comment marker (invisible in rendered
+      # Markdown) rather than `gh pr comment --edit-last`, which would be
+      # fragile if any other workflow ever comments on PRs as github-actions[bot].
+      # All dynamic values flow in via `env:` to keep ${{ ... }} out of the shell
+      # body (script-injection class).
+      - name: Post or update PR build comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
+          BUILD_VERSION: ${{ steps.version.outputs.build_version }}
+          SHA: ${{ steps.vars.outputs.sha_short }}
+          MARKER: '<!-- mcpb-pr-build -->'
+        run: |
+          set -euo pipefail
+
+          BODY_FILE="${RUNNER_TEMP}/mcpb-pr-body.md"
+          cat >"${BODY_FILE}" <<EOF
+          ${MARKER}
+          **MCPB build for this PR**
+
+          | Field   | Value |
+          |---------|-------|
+          | Bundle  | [Download .mcpb](${ARTIFACT_URL}) |
+          | Version | \`${BUILD_VERSION}\` |
+          | Commit  | \`${SHA}\` |
+          | Run     | [#${RUN_ID}](https://github.com/${REPO}/actions/runs/${RUN_ID}) |
+
+          _Artifact retained 14 days. This comment auto-updates on each push._
+          EOF
+
+          COMMENT_ID=$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
+            --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" \
+            | head -n1)
+
+          if [ -n "${COMMENT_ID}" ]; then
+            gh api -X PATCH "repos/${REPO}/issues/comments/${COMMENT_ID}" \
+              -F body=@"${BODY_FILE}" >/dev/null
+            echo "Updated existing comment ${COMMENT_ID} on PR #${PR}"
+          else
+            NEW_ID=$(gh api -X POST "repos/${REPO}/issues/${PR}/comments" \
+              -F body=@"${BODY_FILE}" --jq '.id')
+            echo "Posted new comment ${NEW_ID} on PR #${PR}"
+          fi

--- a/.github/workflows/build-bundle-pr.yml
+++ b/.github/workflows/build-bundle-pr.yml
@@ -76,7 +76,12 @@ jobs:
       # fragile if any other workflow ever comments on PRs as github-actions[bot].
       # All dynamic values flow in via `env:` to keep ${{ ... }} out of the shell
       # body (script-injection class).
+      # Skipped on fork PRs: `pull_request` from a fork gets a read-only
+      # GITHUB_TOKEN regardless of the `permissions:` block, so the gh api call
+      # would 403 and paint a red ✗ on every external-contributor PR. The
+      # artifact link is still reachable from the Actions run page.
       - name: Post or update PR build comment
+        if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Every note-scoped tool response now carries a `Revision: <n>` line** alongside the note ID, sourced from Bear's `ZSFNOTE.Z_OPT` counter. An LLM agent can compare revisions between calls to detect "did this note change since I last read it" — useful when you edit in Bear's UI between agent turns. ([#125](https://github.com/vasylenko/bear-notes-mcp/pull/125))
   - **Stale-revision writes are now rejected on body-modifying note tools.** Catches the failure mode where an agent reads a note, the user (or another sync) edits it in Bear, and the agent later writes from its now-stale view — landing the write at the wrong place or on content whose meaning has shifted. ([#128](https://github.com/vasylenko/bear-notes-mcp/pull/128))
 
+### Internal
+
+- **PRs get a sticky `.mcpb` download comment** — each `pull_request` build now posts (and updates on subsequent pushes) a single comment with a link to the freshly-built bundle, the build version, short SHA, and the workflow run. Reviewers and contributors can install a PR's build without digging into the Actions tab. Skipped on fork PRs to avoid a 403 from the read-only `GITHUB_TOKEN`. ([#129](https://github.com/vasylenko/bear-notes-mcp/pull/129))
+
 ## [3.0.1] - 2026-05-12
 
 ### Internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
-- **PRs get a sticky `.mcpb` download comment** — each `pull_request` build now posts (and updates on subsequent pushes) a single comment with a link to the freshly-built bundle, the build version, short SHA, and the workflow run. Reviewers and contributors can install a PR's build without digging into the Actions tab. Skipped on fork PRs to avoid a 403 from the read-only `GITHUB_TOKEN`. ([#129](https://github.com/vasylenko/bear-notes-mcp/pull/129))
+- **PRs get a sticky `.mcpb` download comment** — each `pull_request` build now posts (and updates on subsequent pushes) a single comment with a link to the freshly-built bundle, the build version, short SHA, and the workflow run. Skipped on fork PRs to avoid a 403 from the read-only `GITHUB_TOKEN`. ([#129](https://github.com/vasylenko/bear-notes-mcp/pull/129))
 
 ## [3.0.1] - 2026-05-12
 


### PR DESCRIPTION
## Summary
- On every PR push, posts (or updates in place) a single sticky comment on the PR with a direct download link to the freshly-built `.mcpb`, plus version, short SHA, and run link.
- Comment is identified by a hidden HTML marker so subsequent pushes update the same comment rather than appending new ones.

## Why
Before this, grabbing a PR build meant clicking into the Actions tab, finding the run, and scrolling to the artifacts list. This makes the link one click from the PR conversation.

This PR is its own test fixture: after it lands as an open PR, the workflow on this branch's head runs against itself. Expected behavior on a second push is the same comment ID updated in place (`updated_at > created_at`, count of marker-tagged bot comments stays at 1).

--
