### PR TITLE
docs: weekly review 2026-05-21

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ MCP server for Bear Notes, distributed through two channels:
 
 ## Source Layout
 
-`src/` is layered as **infra → operations → tools**. Adapters to external systems (SQLite, filesystem, Bear URL scheme) live in `infra/`; pure business logic in `operations/`; MCP tool registrations and handlers in `tools/`. Dependencies flow downward only — `tools/` may import from `operations/` and `infra/`, `operations/` from `infra/`, never the reverse. Tests are co-located with their source files using the `.test.ts` suffix. Use `find src -type f` for the current file list; the rules above are what's load-bearing.
+`src/` is layered as **infra → operations → tools**. Adapters to external systems (SQLite, Bear URL scheme) live in `infra/`; pure business logic in `operations/`; MCP tool registrations and handlers in `tools/`. Dependencies flow downward only — `tools/` may import from `operations/` and `infra/`, `operations/` from `infra/`, never the reverse. Tests are co-located with their source files using the `.test.ts` suffix. Use `find src -type f` for the current file list; the rules above are what's load-bearing.
 
 ## Additional technical context
 


### PR DESCRIPTION
## Summary

The weekly documentation review found one factual inaccuracy in `CLAUDE.md`: the Source Layout section listed "filesystem" as an external system adapter living in `src/infra/`, but no such adapter exists there. The filesystem access for `bear-add-file` (`readAttachmentFile`) is implemented inline in `src/tools/note-tools.ts`. The only external system adapters in `src/infra/` are the SQLite adapter (`database.ts`) and the Bear URL scheme adapter (`bear-urls.ts`).

## Changes

- [ ] **CLAUDE.md** — Source Layout section claimed `(SQLite, filesystem, Bear URL scheme)` adapters live in `infra/`; removed `filesystem` from the list since no filesystem adapter exists in `src/infra/` (`readAttachmentFile` is in `src/tools/note-tools.ts`)

## No Issues Found

The following checklist areas were verified accurate:

- **Reference Accuracy**: All referenced files, constants, and file paths match the codebase (e.g., `REVISION_POLL_TARGET_MS`, `POLL_TIMEOUT_MS`, `database.ts:59`, system test at `tests/system/registration-gate.test.ts`, `src/infra/bear-schema.test.ts` FTS5 guard)
- **Configuration Options**: All three env vars (`UI_DEBUG_TOGGLE`, `UI_ENABLE_NEW_NOTE_CONVENTION`, `UI_ENABLE_CONTENT_REPLACEMENT`) correctly documented in README.md, NPM.md, manifest.json, and website
- **Feature Behavior Descriptions**: Tool count (4 read + 8 write), file attachment limit (25 MB), BM25 weights (2.0/2.0/0.5), snippet sizes (80-token FTS5 / 200-char filter-only), OCC polling behavior all match code
- **Installation and Setup**: Node.js version requirement (24.13.0+) matches `package.json`; install commands verified; database path (`~/Library/Group Containers/...`) matches `database.ts`
- **Architecture Spec**: READ/WRITE path diagram, layer boundaries, FTS5 index behavior, OCC inform/enforce split all match implementation
- **Cross-Document Consistency**: Tool counts, env var names, and Node version are consistent across README.md, NPM.md, CLAUDE.md, manifest.json, and website components

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELUrMH3rY7VahmHnySN9VP)_