### PR TITLE
docs: weekly review 2026-06-11

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,11 +8,11 @@ Never assume — only state what you know for sure based on the new code you rev
 
 ## Review Guidelines
 1. Review for KISS and DRY
-- Carefully read the .claude/commands/kissdryer.md file, which explains how to review the code for KISS and DRY principles.
+- Carefully read the docs/dev/SPECIFICATION.md file, which explains the system architecture and design constraints (including KISS/YAGNI principles) for this project.
 - Using this knowledge, diligently review the PR changes according to these principles.
 
 2. Review for Codestyle
-- Carefully read the .claude/commands/codestyle.md file, which explains how to review the code for the style rules of this project.
+- Carefully read the docs/dev/CODE_STYLE.md file, which explains the style rules of this project.
 - Using this knowledge, diligently review the PR changes according to the style guides.
 
 ---


### PR DESCRIPTION
## Summary

Reviewed all user-facing and maintainer-facing documentation against the current codebase. One stale file reference was found in `.github/copilot-instructions.md`: both `.claude/commands/kissdryer.md` and `.claude/commands/codestyle.md` are referenced but neither file exists in the repository (`.claude/` contains only `settings.json`). Updated both references to point to the actual project docs that cover the same ground.

## Changes

- [ ] `.claude/commands/kissdryer.md` → `docs/dev/SPECIFICATION.md` and `.claude/commands/codestyle.md` → `docs/dev/CODE_STYLE.md` in `.github/copilot-instructions.md` — stale paths replaced with the files that actually exist and cover KISS/YAGNI design constraints and code style rules respectively

## No Issues Found

The following checklist areas were checked and found accurate:

- **Reference accuracy**: All tool descriptions match between `README.md`, `docs/user/NPM.md`, and `manifest.json` (synced via `task docs:sync`). All env var names (`UI_DEBUG_TOGGLE`, `UI_ENABLE_NEW_NOTE_CONVENTION`, `UI_ENABLE_CONTENT_REPLACEMENT`) and their defaults are consistent across all docs and the code.
- **Configuration options**: Node.js `^24.13.0` requirement, 25 MB file size cap, all three user-config fields match `src/config.ts` and `manifest.json`.
- **Feature behavior descriptions**: Tool counts (4 read + 8 write = 12 Bear-domain tools + 1 capabilities = 13 total), OCC constants (`REVISION_POLL_TARGET_MS = 1_000`, `POLL_TIMEOUT_MS = 2_000`, `REVISION_POLL_INTERVAL_MS = 15`), BM25 weights (title/body=2.0, ocr=0.5), FTS snippet (80 tokens), filter-only snippet (200 chars), and `busy_timeout = 3000` at `database.ts:59` all match code.
- **Installation and setup**: All install commands, paths, and prerequisites verified accurate.
- **Architecture spec**: Hybrid read (SQLite) / write (Bear URL scheme) model, registration-time write gating via `applyWriteGate`, OCC inform/enforce halves, schema discovery (`discoverBearSchema`), in-memory FTS5 index with MAX+COUNT drift check, and `spawn('open', ['-g', ...])` subprocess invocation all match the code.
- **Cross-document consistency**: Tool lists, tool counts, env var names, and OCC behavior descriptions are consistent across `README.md`, `docs/user/NPM.md`, `docs/dev/SPECIFICATION.md`, `docs/dev/SECURITY.md`, `docs/dev/BEAR_DATABASE_SCHEMA.md`, `CLAUDE.md`, and website components.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx8q9DYtBHR9PLjbAUpKHV)_