### PR TITLE
docs: weekly review 2026-07-09

### DIFF
--- a/docs/dev/SPECIFICATION.md
+++ b/docs/dev/SPECIFICATION.md
@@ -200,7 +200,7 @@ Bear uses Core Data with SQLite. The schema is undocumented; the DB is small eno
 
 - **Encrypted notes**: Bear encrypts content in the DB. Excluded from all queries.
 - **Per-tag pinning**: Bear's URL scheme supports `pin=yes` for global pinning but has no action for pinning within a specific tag.
-- **Write verification**: No way to confirm Bear processed a URL action. Exit code 0 from `open` only means macOS accepted the URL, not that Bear acted on it.
+- **Write verification** _(partially lifted)_: For writes that bump `ZSFNOTE.Z_OPT`, OCC polling confirms the write landed — see _Safety Gates → Optimistic Concurrency Control → Inform half_. The constraint persists for writes that do not bump `Z_OPT` (global tag operations: `bear-rename-tag`, `bear-delete-tag`): exit code 0 from `open` only means macOS accepted the URL, not that Bear acted on it.
 
 ---
 


### PR DESCRIPTION
## Summary

Reviewed all user-facing and maintainer-facing documentation against the current codebase (v3.0.1 + Unreleased OCC work). Found one factual inaccuracy: the "Intentional Exclusions" section of `SPECIFICATION.md` contained a stale "Write verification" entry that no longer accurately described the system — OCC polling, which ships in the Unreleased branch and is already documented in the OCC section of the same file, partially lifts that constraint for writes that bump `Z_OPT`.

## Changes

- [ ] **`docs/dev/SPECIFICATION.md` — "Write verification" Intentional Exclusion is stale → updated to reflect the partial lift**: The entry read "No way to confirm Bear processed a URL action. Exit code 0 from `open` only means macOS accepted the URL, not that Bear acted on it." The OCC section of the same document already notes "Constraint partially lifted: write verification" and cross-references this entry, but the entry itself was never updated. Fixed: the entry now states the constraint is partially lifted for writes that bump `Z_OPT`, names the remaining scope (global tag ops), and links to the OCC section.

## No Issues Found

The following checklist areas were checked and found accurate:

- **Reference Accuracy** — all file paths, function names, constants (`REVISION_POLL_TARGET_MS`, `REVISION_POLL_INTERVAL_MS`, `POLL_TIMEOUT_MS`, `busy_timeout`), and cross-references verified against the source.
- **Configuration Options** — `UI_DEBUG_TOGGLE`, `UI_ENABLE_NEW_NOTE_CONVENTION`, `UI_ENABLE_CONTENT_REPLACEMENT` consistent across README, NPM.md, manifest.json, config.ts, SPECIFICATION.md, and website components.
- **Feature Behavior Descriptions** — tool count (4 read + 8 write + 1 bear-capabilities), Edit Mode gate, OCC enforce/inform patterns, FTS5 search, drift check, per-column BM25 weights, and attachment size cap all match the implementation.
- **Installation and Setup** — Node.js 24.13.0+ requirement consistent across README, NPM.md, package.json, manifest.json, and website FAQ.
- **Architecture Spec** — database path, layer boundaries (infra → operations → tools), write model, background execution via `open -g`, schema discovery at runtime, and test constraints all accurate.
- **Cross-Document Consistency** — tool counts, env var names, Node.js version, database path, and gate behavior consistent across README, NPM.md, SPECIFICATION.md, SECURITY.md, BEAR_DATABASE_SCHEMA.md, CLAUDE.md, website components, and manifest.json.

---
_Generated by [Claude Code](https://claude.ai/code/session_0192YYZBJVbSCSJvQxdMFkN4)_